### PR TITLE
adjust/block-num-col

### DIFF
--- a/macros/streamline/bronze/streamline_external_table_query.sql
+++ b/macros/streamline/bronze/streamline_external_table_query.sql
@@ -27,12 +27,12 @@
 
         {% if block_number %},
             COALESCE(
-                s.value :"BLOCK_NUMBER" :: INT,
-                (s.metadata :request :"data" :id :: STRING) :: INT,
-                (PARSE_JSON(
+                s.value :"BLOCK_NUMBER" :: STRING,
+                s.metadata :request :"data" :id :: STRING,
+                PARSE_JSON(
                     s.metadata :request :"data"
-                ) :id :: STRING) :: INT
-            ) AS block_number
+                ) :id :: STRING
+            ) :: INT AS block_number
         {% endif %}
         FROM
             {{ source(
@@ -88,13 +88,13 @@ SELECT
 
 {% if block_number %},
     COALESCE(
-        s.value :"BLOCK_NUMBER" :: INT,
-        s.value :"block_number" :: INT,
-        (s.metadata :request :"data" :id :: STRING) :: INT,
-        (PARSE_JSON(
+        s.value :"BLOCK_NUMBER" :: STRING,
+        s.value :"block_number" :: STRING,
+        s.metadata :request :"data" :id :: STRING,
+        PARSE_JSON(
             s.metadata :request :"data"
-        ) :id :: STRING) :: INT
-    ) AS block_number
+        ) :id :: STRING
+    ) :: INT AS block_number
 {% endif %}
 FROM
     {{ source(

--- a/macros/streamline/bronze/streamline_external_table_query.sql
+++ b/macros/streamline/bronze/streamline_external_table_query.sql
@@ -47,10 +47,7 @@
             {% if balances %}
             JOIN {{ ref('_block_ranges') }}
             r
-            ON r.block_number = COALESCE(
-                s.value :"BLOCK_NUMBER" :: INT,
-                s.value :"block_number" :: INT
-            )
+            ON r.block_number = s.block_number
         {% endif %}
         WHERE
             b.partition_key = s.partition_key
@@ -109,10 +106,7 @@ FROM
     {% if balances %}
         JOIN {{ ref('_block_ranges') }}
         r
-        ON r.block_number = COALESCE(
-            s.value :"BLOCK_NUMBER" :: INT,
-            s.value :"block_number" :: INT
-        )
+        ON r.block_number = s.block_number
     {% endif %}
 WHERE
     b.partition_key = s.{{ partition_join_key }}
@@ -125,7 +119,7 @@ WHERE
     ) %}
 SELECT
     partition_key,
-    VALUE :"BLOCK_NUMBER" :: INT AS block_number,
+    block_number,
     {% if model == 'receipts' or model == 'traces' %}
         array_index,
     {% endif %}

--- a/macros/streamline/bronze/streamline_external_table_query.sql
+++ b/macros/streamline/bronze/streamline_external_table_query.sql
@@ -47,7 +47,10 @@
             {% if balances %}
             JOIN {{ ref('_block_ranges') }}
             r
-            ON r.block_number = s.block_number
+            ON r.block_number = COALESCE(
+                s.value :"BLOCK_NUMBER" :: INT,
+                s.value :"block_number" :: INT
+            )
         {% endif %}
         WHERE
             b.partition_key = s.partition_key
@@ -106,7 +109,10 @@ FROM
     {% if balances %}
         JOIN {{ ref('_block_ranges') }}
         r
-        ON r.block_number = s.block_number
+        ON r.block_number = COALESCE(
+            s.value :"BLOCK_NUMBER" :: INT,
+            s.value :"block_number" :: INT
+        )
     {% endif %}
 WHERE
     b.partition_key = s.{{ partition_join_key }}

--- a/macros/streamline/bronze/streamline_external_table_query.sql
+++ b/macros/streamline/bronze/streamline_external_table_query.sql
@@ -28,10 +28,10 @@
         {% if block_number %},
             COALESCE(
                 s.value :"BLOCK_NUMBER" :: INT,
-                s.metadata :request :"data" :id :: INT,
-                PARSE_JSON(
+                (s.metadata :request :"data" :id :: STRING) :: INT,
+                (PARSE_JSON(
                     s.metadata :request :"data"
-                ) :id :: INT
+                ) :id :: STRING) :: INT
             ) AS block_number
         {% endif %}
         FROM
@@ -90,10 +90,10 @@ SELECT
     COALESCE(
         s.value :"BLOCK_NUMBER" :: INT,
         s.value :"block_number" :: INT,
-        s.metadata :request :"data" :id :: INT,
-        PARSE_JSON(
+        (s.metadata :request :"data" :id :: STRING) :: INT,
+        (PARSE_JSON(
             s.metadata :request :"data"
-        ) :id :: INT
+        ) :id :: STRING) :: INT
     ) AS block_number
 {% endif %}
 FROM

--- a/macros/streamline/silver/core/streamline_core_complete.sql
+++ b/macros/streamline/silver/core/streamline_core_complete.sql
@@ -2,14 +2,7 @@
         model
     ) %}
 SELECT
-    COALESCE(
-        VALUE :"BLOCK_NUMBER" :: INT,
-        VALUE :"block_number" :: INT,
-        metadata :request :"data" :id :: INT,
-        PARSE_JSON(
-            metadata :request :"data"
-        ) :id :: INT
-    ) AS block_number,
+    block_number,
     file_name,
     {{ dbt_utils.generate_surrogate_key(
         ['block_number']


### PR DESCRIPTION
1. Removes COALESCE syntax from `block_number` column references from bronze streamline
2. New version tag v1.6.0