### PR TITLE
Add optional retry logic

### DIFF
--- a/macros/core/gold/core_traces.sql
+++ b/macros/core/gold/core_traces.sql
@@ -4,7 +4,8 @@
         full_reload_mode = false,
         uses_overflow_steps = false,
         arb_traces_mode = false,
-        schema_name = 'silver'
+        schema_name = 'silver',
+        sei_traces_mode = false
     ) %}
     WITH silver_traces AS (
         SELECT

--- a/macros/core/gold/core_traces.sql
+++ b/macros/core/gold/core_traces.sql
@@ -231,9 +231,9 @@ trace_index_sub_traces AS (
         ROW_NUMBER() over (
             PARTITION BY b.block_number,
             {% if sei_traces_mode %}
-                b.tx_hash,
+                b.tx_hash
             {% else %}
-                b.tx_position,
+                b.tx_position
             {% endif %}
             ORDER BY
                 number_array ASC

--- a/macros/core/gold/core_traces_v2.sql
+++ b/macros/core/gold/core_traces_v2.sql
@@ -6,12 +6,17 @@
         uses_overflow_steps = false,
         arb_traces_mode = false,
         schema_name = 'silver',
-        uses_tx_status = false
+        uses_tx_status = false,
+        sei_traces_mode = false
     ) %}
     WITH silver_traces AS (
         SELECT
             block_number,
-            tx_position,
+            {% if sei_traces_mode %}
+                tx_hash,
+            {% else %}
+                tx_position,
+            {% endif %}
             trace_address,
             parent_trace_address,
             trace_address_array,
@@ -56,7 +61,11 @@ AND (
 UNION ALL
 SELECT
     block_number,
-    tx_position,
+    {% if sei_traces_mode %}
+        tx_hash,
+    {% else %}
+        tx_position,
+    {% endif %}
     trace_address,
     parent_trace_address,
     trace_address_array,
@@ -147,27 +156,43 @@ AND modified_timestamp > (
 sub_traces AS (
     SELECT
         block_number,
-        tx_position,
+        {% if sei_traces_mode %}
+            tx_hash,
+        {% else %}
+            tx_position,
+        {% endif %}
         parent_trace_address,
         COUNT(*) AS sub_traces
     FROM
         silver_traces
     GROUP BY
         block_number,
-        tx_position,
+        {% if sei_traces_mode %}
+            tx_hash,
+        {% else %}
+            tx_position,
+        {% endif %}
         parent_trace_address
 ),
 trace_index_array AS (
     SELECT
         block_number,
-        tx_position,
+        {% if sei_traces_mode %}
+            tx_hash,
+        {% else %}
+            tx_position,
+        {% endif %}
         trace_address,
         ARRAY_AGG(flat_value) AS number_array
     FROM
         (
             SELECT
                 block_number,
-                tx_position,
+                {% if sei_traces_mode %}
+                    tx_hash,
+                {% else %}
+                    tx_position,
+                {% endif %}
                 trace_address,
                 IFF(
                     VALUE :: STRING = 'ORIGIN',
@@ -182,13 +207,21 @@ trace_index_array AS (
         )
     GROUP BY
         block_number,
-        tx_position,
+        {% if sei_traces_mode %}
+            tx_hash,
+        {% else %}
+            tx_position,
+        {% endif %}
         trace_address
 ),
 trace_index_sub_traces AS (
     SELECT
         b.block_number,
-        b.tx_position,
+        {% if sei_traces_mode %}
+            b.tx_hash,
+        {% else %}
+            b.tx_position,
+        {% endif %}
         b.trace_address,
         IFNULL(
             sub_traces,
@@ -197,7 +230,11 @@ trace_index_sub_traces AS (
         number_array,
         ROW_NUMBER() over (
             PARTITION BY b.block_number,
-            b.tx_position
+            {% if sei_traces_mode %}
+                b.tx_hash,
+            {% else %}
+                b.tx_position,
+            {% endif %}
             ORDER BY
                 number_array ASC
         ) - 1 AS trace_index,
@@ -208,17 +245,29 @@ trace_index_sub_traces AS (
         silver_traces b
         LEFT JOIN sub_traces s
         ON b.block_number = s.block_number
-        AND b.tx_position = s.tx_position
+        AND {% if sei_traces_mode %}
+                b.tx_hash = s.tx_hash
+            {% else %}
+                b.tx_position = s.tx_position
+            {% endif %}
         AND b.trace_address = s.parent_trace_address
         JOIN trace_index_array n
         ON b.block_number = n.block_number
-        AND b.tx_position = n.tx_position
+        AND {% if sei_traces_mode %}
+                b.tx_hash = n.tx_hash
+            {% else %}
+                b.tx_position = n.tx_position
+            {% endif %}
         AND b.trace_address = n.trace_address
 ),
 errored_traces AS (
     SELECT
         block_number,
-        tx_position,
+        {% if sei_traces_mode %}
+            tx_hash,
+        {% else %}
+            tx_position,
+        {% endif %}
         trace_address,
         trace_json
     FROM
@@ -229,7 +278,11 @@ errored_traces AS (
 error_logic AS (
     SELECT
         b0.block_number,
-        b0.tx_position,
+        {% if sei_traces_mode %}
+            b0.tx_hash,
+        {% else %}
+            b0.tx_position,
+        {% endif %}
         b0.trace_address,
         b0.trace_json :error :: STRING AS error,
         b1.trace_json :error :: STRING AS any_error,
@@ -238,20 +291,32 @@ error_logic AS (
         trace_index_sub_traces b0
         LEFT JOIN errored_traces b1
         ON b0.block_number = b1.block_number
-        AND b0.tx_position = b1.tx_position
+        {% if sei_traces_mode %}
+            AND b0.tx_hash = b1.tx_hash
+        {% else %}
+            AND b0.tx_position = b1.tx_position
+        {% endif %}
         AND b0.trace_address LIKE CONCAT(
             b1.trace_address,
             '_%'
         )
         LEFT JOIN errored_traces b2
         ON b0.block_number = b2.block_number
-        AND b0.tx_position = b2.tx_position
+        {% if sei_traces_mode %}
+            AND b0.tx_hash = b2.tx_hash
+        {% else %}
+            AND b0.tx_position = b2.tx_position
+        {% endif %}
         AND b2.trace_address = 'ORIGIN'
 ),
 aggregated_errors AS (
     SELECT
         block_number,
-        tx_position,
+        {% if sei_traces_mode %}
+            tx_hash,
+        {% else %}
+            tx_position,
+        {% endif %}
         trace_address,
         error,
         IFF(MAX(any_error) IS NULL
@@ -261,7 +326,11 @@ aggregated_errors AS (
         error_logic
     GROUP BY
         block_number,
-        tx_position,
+        {% if sei_traces_mode %}
+            tx_hash,
+        {% else %}
+            tx_position,
+        {% endif %}
         trace_address,
         error,
         origin_error),
@@ -269,7 +338,11 @@ aggregated_errors AS (
             (
                 SELECT
                     block_number,
-                    tx_position,
+                    {% if sei_traces_mode %}
+                        tx_hash,
+                    {% else %}
+                        tx_position,
+                    {% endif %}
                     trace_address,
                     sub_traces,
                     number_array,
@@ -308,7 +381,11 @@ aggregated_errors AS (
                     trace_index_sub_traces
                     JOIN aggregated_errors USING (
                         block_number,
-                        tx_position,
+                        {% if sei_traces_mode %}
+                            tx_hash,
+                        {% else %}
+                            tx_position,
+                        {% endif %}
                         trace_address
                     )
                 {% else %}
@@ -432,12 +509,20 @@ aggregated_errors AS (
                     incremental_traces AS (
                         SELECT
                             f.block_number,
-                            t.tx_hash,
+                            {% if sei_traces_mode %}
+                                f.tx_hash,
+                            {% else %}
+                                t.tx_hash,
+                            {% endif %}
                             t.block_timestamp,
                             t.origin_function_signature,
                             t.from_address AS origin_from_address,
                             t.to_address AS origin_to_address,
+                            {% if sei_traces_mode %}
+                                t.position AS tx_position,
+                            {% else %}
                             f.tx_position,
+                            {% endif %}
                             f.trace_index,
                             f.from_address AS from_address,
                             f.to_address AS to_address,
@@ -471,7 +556,11 @@ aggregated_errors AS (
                                 schema_name ~ '__transactions'
                             ) }}
                             t
-                            ON f.tx_position = t.position
+                            ON {% if sei_traces_mode %}
+                                f.tx_hash = t.tx_hash
+                            {% else %}
+                                f.tx_position = t.position
+                            {% endif %}
                             AND f.block_number = t.block_number
 
 {% if is_incremental() and not full_reload_mode %}
@@ -495,12 +584,20 @@ overflow_blocks AS (
 heal_missing_data AS (
     SELECT
         t.block_number,
-        txs.tx_hash,
+        {% if sei_traces_mode %}
+            t.tx_hash,
+        {% else %}
+            txs.tx_hash,
+        {% endif %}
         txs.block_timestamp,
         txs.origin_function_signature,
         txs.from_address AS origin_from_address,
         txs.to_address AS origin_to_address,
-        t.tx_position,
+        {% if sei_traces_mode %}
+            txs.position AS tx_position,
+        {% else %}
+            t.tx_position,
+        {% endif %}
         t.trace_index,
         t.from_address,
         t.to_address,
@@ -535,10 +632,19 @@ heal_missing_data AS (
             schema_name ~ '__transactions'
         ) }}
         txs
-        ON t.tx_position = txs.position
+        {% if sei_traces_mode %}
+            ON t.tx_hash = txs.tx_hash
+        {% else %}
+            ON t.tx_position = txs.position
+        {% endif %}
+        AND t.block_
         AND t.block_number = txs.block_number
     WHERE
-        t.tx_hash IS NULL
+        {% if sei_traces_mode %}
+            t.tx_position IS NULL
+        {% else %}
+            t.tx_hash IS NULL
+        {% endif %}
         OR t.block_timestamp IS NULL
         OR t.tx_succeeded IS NULL
 )
@@ -687,7 +793,7 @@ SELECT
     SYSDATE() AS inserted_timestamp,
     SYSDATE() AS modified_timestamp
 FROM
-    all_traces qualify(ROW_NUMBER() over(PARTITION BY block_number, tx_position, trace_index
+    all_traces qualify(ROW_NUMBER() over(PARTITION BY block_number,  {% if sei_traces_mode %}tx_hash, {% else %}tx_position, {% endif %} trace_index
 ORDER BY
     modified_timestamp DESC, block_timestamp DESC nulls last)) = 1
 {% endmacro %}

--- a/macros/streamline/bronze/streamline_external_table_query.sql
+++ b/macros/streamline/bronze/streamline_external_table_query.sql
@@ -136,21 +136,7 @@ SELECT
     file_name,
     _inserted_timestamp
 FROM
-    {% if model == 'blocks' %}
-        {{ ref('bronze__streamline_fr_blocks_v2') }}
-
-        {% elif model == 'confirmed_blocks' %}
-        {{ ref('bronze__streamline_fr_confirmed_blocks_v2') }}
-
-        {% elif model == 'transactions' %}
-        {{ ref('bronze__streamline_fr_transactions_v2') }}
-
-        {% elif model == 'receipts' %}
-        {{ ref('bronze__streamline_fr_receipts_v2') }}
-
-        {% elif model == 'traces' %}
-        {{ ref('bronze__streamline_fr_traces_v2') }}
-    {% endif %}
+    {{ ref('bronze__streamline_fr_' ~ model ~ '_v2') }}
 UNION ALL
 SELECT
     _partition_by_block_id AS partition_key,
@@ -165,21 +151,7 @@ SELECT
     file_name,
     _inserted_timestamp
 FROM
-    {% if model == 'blocks' %}
-        {{ ref('bronze__streamline_fr_blocks_v1') }}
-
-        {% elif model == 'confirmed_blocks' %}
-        {{ ref('bronze__streamline_fr_confirmed_blocks_v1') }}
-
-        {% elif model == 'transactions' %}
-        {{ ref('bronze__streamline_fr_transactions_v1') }}
-
-        {% elif model == 'receipts' %}
-        {{ ref('bronze__streamline_fr_receipts_v1') }}
-
-        {% elif model == 'traces' %}
-        {{ ref('bronze__streamline_fr_traces_v1') }}
-    {% endif %}
+    {{ ref('bronze__streamline_fr_' ~ model ~ '_v1') }}
 {% endmacro %}
 
 {% macro streamline_external_table_query_decoder(

--- a/macros/streamline/silver/core/streamline_core_complete.sql
+++ b/macros/streamline/silver/core/streamline_core_complete.sql
@@ -1,65 +1,26 @@
-{% macro streamline_core_complete(
-        model
-    ) %}
+{% macro streamline_core_complete(model) %}
 SELECT
     block_number,
     file_name,
-    {{ dbt_utils.generate_surrogate_key(
-        ['block_number']
-    ) }} AS {% if model == 'blocks' %}
-        complete_blocks_id {% elif model == 'transactions' %}
-        complete_transactions_id {% elif model == 'receipts' %}
-        complete_receipts_id {% elif model == 'traces' %}
-        complete_traces_id {% elif model == 'confirmed_blocks' %}
-        complete_confirmed_blocks_id
-    {% endif %},
+    {{ dbt_utils.generate_surrogate_key(['block_number']) }} AS complete_{{ model }}_id,
     SYSDATE() AS inserted_timestamp,
     SYSDATE() AS modified_timestamp,
     _inserted_timestamp,
     '{{ invocation_id }}' AS _invocation_id
 FROM
+    {% if is_incremental() %}
+        {{ ref('bronze__streamline_' ~ model) }}
+    WHERE
+        _inserted_timestamp >= (
+            SELECT
+                COALESCE(MAX(_inserted_timestamp), '1970-01-01'::TIMESTAMP) AS _inserted_timestamp
+            FROM
+                {{ this }}
+        )
+    {% else %}
+        {{ ref('bronze__streamline_fr_' ~ model) }}
+    {% endif %}
 
-{% if is_incremental() %}
-{% if model == 'blocks' %}
-    {{ ref('bronze__streamline_blocks') }}
+QUALIFY (ROW_NUMBER() OVER (PARTITION BY block_number ORDER BY _inserted_timestamp DESC)) = 1
 
-    {% elif model == 'transactions' %}
-    {{ ref('bronze__streamline_transactions') }}
-
-    {% elif model == 'receipts' %}
-    {{ ref('bronze__streamline_receipts') }}
-
-    {% elif model == 'traces' %}
-    {{ ref('bronze__streamline_traces') }}
-
-    {% elif model == 'confirmed_blocks' %}
-    {{ ref('bronze__streamline_confirmed_blocks') }}
-{% endif %}
-WHERE
-    _inserted_timestamp >= (
-        SELECT
-            COALESCE(MAX(_inserted_timestamp), '1970-01-01' :: TIMESTAMP) AS _inserted_timestamp
-        FROM
-            {{ this }})
-        {% else %}
-            {% if model == 'blocks' %}
-                {{ ref('bronze__streamline_fr_blocks') }}
-
-                {% elif model == 'transactions' %}
-                {{ ref('bronze__streamline_fr_transactions') }}
-
-                {% elif model == 'receipts' %}
-                {{ ref('bronze__streamline_fr_receipts') }}
-
-                {% elif model == 'traces' %}
-                {{ ref('bronze__streamline_fr_traces') }}
-
-                {% elif model == 'confirmed_blocks' %}
-                {{ ref('bronze__streamline_fr_confirmed_blocks') }}
-            {% endif %}
-        {% endif %}
-
-        qualify(ROW_NUMBER() over (PARTITION BY block_number
-        ORDER BY
-            _inserted_timestamp DESC)) = 1
 {% endmacro %}

--- a/macros/streamline/silver/core/streamline_core_requests.sql
+++ b/macros/streamline/silver/core/streamline_core_requests.sql
@@ -1,7 +1,7 @@
 {% macro streamline_core_chainhead(
     quantum_state,
     vault_secret_path,
-    api_url='{service}/{Authentication}'
+    api_url='{Service}/{Authentication}'
 ) %}
 SELECT
     live.udf_api(
@@ -44,7 +44,7 @@ SELECT
     quantum_state,
     vault_secret_path,
     query_limit,
-    api_url='{service}/{Authentication}',
+    api_url='{Service}/{Authentication}',
     order_by_clause='ORDER BY partition_key ASC',
     new_build=false,
     testing_limit=none

--- a/macros/streamline/silver/core/streamline_core_requests.sql
+++ b/macros/streamline/silver/core/streamline_core_requests.sql
@@ -70,9 +70,9 @@ to_do AS (
     FROM {{ ref("streamline__blocks") }}
     WHERE 
         block_number IS NOT NULL
+        {% if not new_build %}
         AND block_number
         {% if model_type == 'realtime' %}>={% elif model_type == 'history' %}<={% endif %}
-        {% if not new_build %}
             (SELECT block_number FROM last_3_days)
         {% endif %}
         {% if model == 'confirmed_blocks' and not new_build %}

--- a/macros/streamline/silver/core/streamline_core_requests.sql
+++ b/macros/streamline/silver/core/streamline_core_requests.sql
@@ -45,7 +45,8 @@ SELECT
     vault_secret_path,
     query_limit,
     api_url='{service}/{Authentication}',
-    order_by_clause='ORDER BY partition_key ASC'
+    order_by_clause='ORDER BY partition_key ASC',
+    uses_retry = true
 ) %}
 
 WITH last_3_days AS (
@@ -149,6 +150,7 @@ to_do AS (
         block_number
     FROM
         to_do
+    {% if uses_retry %}
     UNION
     SELECT
         block_number
@@ -180,6 +182,7 @@ to_do AS (
         {{ ref("_missing_traces") }}
     {% endif %}
     )
+    {% endif %}
 )
 {% endif %}
 SELECT

--- a/macros/streamline/silver/core/streamline_core_requests.sql
+++ b/macros/streamline/silver/core/streamline_core_requests.sql
@@ -87,12 +87,8 @@ to_do AS (
         {% if model == 'blocks_transactions' %}
             {{ ref("streamline__complete_blocks") }} b
             INNER JOIN {{ ref("streamline__complete_transactions") }} t USING(block_number)
-        {% elif model == 'receipts' %}
-            {{ ref("streamline__complete_receipts") }}
-        {% elif model == 'traces' %}
-            {{ ref("streamline__complete_traces") }}
-        {% elif model == 'confirmed_blocks' %}
-            {{ ref("streamline__complete_confirmed_blocks") }}
+        {% else %}
+            {{ ref('streamline__complete_' ~ model) }}
         {% endif %}
     WHERE 1=1
         {% if not new_build %}

--- a/macros/streamline/silver/core/streamline_core_requests.sql
+++ b/macros/streamline/silver/core/streamline_core_requests.sql
@@ -50,214 +50,138 @@ SELECT
 ) %}
 
 WITH 
-
 {% if not new_build %}
+    last_3_days AS (
+        SELECT block_number
+        FROM {{ ref("_block_lookback") }}
+    ),
 
-last_3_days AS (
-    SELECT
-        block_number
-    FROM
-        {{ ref("_block_lookback") }}
-),
-{% if model == 'confirmed_blocks' %}
-look_back AS (
-    SELECT
-        block_number
-    FROM
-        {{ ref("_max_block_by_hour") }}
-        qualify ROW_NUMBER() over (
-            ORDER BY
-                block_number DESC
-        ) = 6
-),
+    {% if model == 'confirmed_blocks' %}
+        look_back AS (
+            SELECT block_number
+            FROM {{ ref("_max_block_by_hour") }}
+            QUALIFY ROW_NUMBER() OVER (ORDER BY block_number DESC) = 6
+        ),
+    {% endif %}
 {% endif %}
-{% endif %}
+
 to_do AS (
-    SELECT
-        block_number
-    FROM
-        {{ ref("streamline__blocks") }}
-    WHERE
+    SELECT block_number
+    FROM {{ ref("streamline__blocks") }}
+    WHERE 
         block_number IS NOT NULL
         AND block_number
-        {% if model_type == 'realtime' %}
-        >= 
-        {% elif model_type == 'history' %}
-        <= 
-        {% endif %}
+        {% if model_type == 'realtime' %}>={% elif model_type == 'history' %}<={% endif %}
         {% if not new_build %}
-        (
-                SELECT
-                    block_number
-                FROM
-                    last_3_days
+            (SELECT block_number FROM last_3_days)
+        {% endif %}
+        {% if model == 'confirmed_blocks' and not new_build %}
+            AND block_number <= (SELECT block_number FROM look_back)
+        {% endif %}
+
+    EXCEPT
+
+    SELECT block_number
+    FROM
+        {% if model == 'blocks_transactions' %}
+            {{ ref("streamline__complete_blocks") }} b
+            INNER JOIN {{ ref("streamline__complete_transactions") }} t USING(block_number)
+        {% elif model == 'receipts' %}
+            {{ ref("streamline__complete_receipts") }}
+        {% elif model == 'traces' %}
+            {{ ref("streamline__complete_traces") }}
+        {% elif model == 'confirmed_blocks' %}
+            {{ ref("streamline__complete_confirmed_blocks") }}
+        {% endif %}
+    WHERE 1=1
+        {% if not new_build %}
+            AND block_number
+            {% if model_type == 'realtime' %}>={% elif model_type == 'history' %}<={% endif %}
+            (SELECT block_number FROM last_3_days)
+            {% if model == 'confirmed_blocks' %}
+                AND block_number IS NOT NULL
+                AND block_number <= (SELECT block_number FROM look_back)
+                AND _inserted_timestamp >= DATEADD('day', -4, SYSDATE())
+                AND block_number >= (SELECT block_number FROM last_3_days)
+            {% endif %}
+        {% endif %}
+)
+
+{% if model != 'confirmed_blocks' %}
+    ,ready_blocks AS (
+        SELECT block_number
+        FROM to_do
+
+        {% if not new_build %}
+            UNION
+            SELECT block_number
+            FROM (
+                SELECT block_number
+                FROM {{ ref("_unconfirmed_blocks") }}
+
+                UNION
+
+                {% if model == 'blocks_transactions' %}
+                    SELECT block_number
+                    FROM {{ ref("_missing_txs") }}
+                {% elif model == 'receipts' %}
+                    SELECT block_number
+                    FROM {{ ref("_missing_txs") }}
+                    UNION
+                    SELECT block_number
+                    FROM {{ ref("_missing_receipts") }}
+                {% elif model == 'traces' %}
+                    SELECT block_number
+                    FROM {{ ref("_missing_traces") }}
+                {% endif %}
             )
         {% endif %}
-        {% if model == 'confirmed_blocks' %}
-        {% if not new_build %}
-        AND block_number <= (
-            SELECT
-                block_number
-            FROM
-                look_back
-        )
-        {% endif %}
-    {% endif %}
-    EXCEPT
-    SELECT
-        block_number
-    FROM
-    {% if model == 'blocks_transactions' %}
-        {{ ref("streamline__complete_blocks") }}
-        b
-        INNER JOIN {{ ref("streamline__complete_transactions") }}
-        t USING(block_number) -- inner join to ensure that only blocks with both block data and transaction data are excluded
-    {% elif model == 'receipts' %}
-        {{ ref("streamline__complete_receipts") }}
-    {% elif model == 'traces' %}
-        {{ ref("streamline__complete_traces") }}
-    {% elif model == 'confirmed_blocks' %}
-        {{ ref("streamline__complete_confirmed_blocks") }}
-    {% endif %}
-    WHERE
-        1=1
-        {% if not new_build %}
-        and block_number
-        {% if model_type == 'realtime' %}
-        >= 
-        {% elif model_type == 'history' %}
-        <= 
-        {% endif %}
-        (
-            SELECT
-                block_number
-            FROM
-                last_3_days
-        )
-    {% endif %}
-    {% if model == 'confirmed_blocks' %}
-        AND block_number IS NOT NULL
-        {% if not new_build %}
-        AND block_number <= (
-            SELECT
-                block_number
-            FROM
-                look_back
-        )
-        {% endif %}
-        AND _inserted_timestamp >= DATEADD(
-            'day',
-            -4,
-            SYSDATE()
-        )
-        AND block_number >= (
-            SELECT
-                block_number
-            FROM
-                last_3_days
-        )
-    {% endif %}
-    {% endif %}
-)
-{% if model != 'confirmed_blocks' %}
-,ready_blocks AS (
-    SELECT
-        block_number
-    FROM
-        to_do
-    {% if not new_build %}
-    UNION
-    SELECT
-        block_number
-    FROM (
-        SELECT
-            block_number
-        FROM
-            {{ ref("_unconfirmed_blocks") }}
-        UNION
-    {% if model == 'blocks_transactions' %}
-    SELECT
-        block_number
-    FROM
-        {{ ref("_missing_txs") }}
-    {% elif model == 'receipts' %}
-    SELECT
-        block_number
-    FROM
-        {{ ref("_missing_txs") }}
-    UNION
-    SELECT
-        block_number
-    FROM
-        {{ ref("_missing_receipts") }}
-    {% elif model == 'traces' %}
-    SELECT
-        block_number
-    FROM
-        {{ ref("_missing_traces") }}
-    {% endif %}
     )
-    {% endif %}
-)
 {% endif %}
+
 SELECT
     block_number,
-    ROUND(
-        block_number,
-        -3
-    ) AS partition_key,
+    ROUND(block_number, -3) AS partition_key,
     live.udf_api(
         'POST',
         '{{ api_url }}',
         OBJECT_CONSTRUCT(
-            'Content-Type',
-            'application/json'
-        {% if quantum_state == 'streamline' %}
-            ,'fsc-quantum-state',
-            'streamline'
+            'Content-Type', 'application/json'
+            {% if quantum_state == 'streamline' %}
+                ,'fsc-quantum-state', 'streamline'
+            {% elif quantum_state == 'livequery' %}
+                ,'fsc-quantum-state', 'livequery'
+            {% endif %}
         ),
-        {% elif quantum_state == 'livequery' %}
-            ,'fsc-quantum-state',
-            'livequery'
-        ),
-        {% else %}
-        ),
-        {% endif %}
         OBJECT_CONSTRUCT(
-            'id',
-            block_number,
-            'jsonrpc',
-            '2.0',
+            'id', block_number,
+            'jsonrpc', '2.0',
             'method',
-        {% if model == 'blocks_transactions' %}
-            'eth_getBlockByNumber',
-            'params',
-            ARRAY_CONSTRUCT(utils.udf_int_to_hex(block_number), TRUE)),
-            --set to TRUE for full txn data
-        {% elif model == 'receipts' %}
-            'eth_getBlockReceipts',
-            'params',
-            ARRAY_CONSTRUCT(utils.udf_int_to_hex(block_number))),
-        {% elif model == 'traces' %}
-            'debug_traceBlockByNumber',
-            'params',
-            ARRAY_CONSTRUCT(utils.udf_int_to_hex(block_number), OBJECT_CONSTRUCT('tracer', 'callTracer', 'timeout', '30s'))),
-        {% elif model == 'confirmed_blocks' %}
-            'eth_getBlockByNumber',
-            'params',
-            ARRAY_CONSTRUCT(utils.udf_int_to_hex(block_number), FALSE)),
-        {% endif %}
+            {% if model == 'blocks_transactions' %}
+                'eth_getBlockByNumber',
+                'params', ARRAY_CONSTRUCT(utils.udf_int_to_hex(block_number), TRUE)
+            {% elif model == 'receipts' %}
+                'eth_getBlockReceipts',
+                'params', ARRAY_CONSTRUCT(utils.udf_int_to_hex(block_number))
+            {% elif model == 'traces' %}
+                'debug_traceBlockByNumber',
+                'params', ARRAY_CONSTRUCT(utils.udf_int_to_hex(block_number), OBJECT_CONSTRUCT('tracer', 'callTracer', 'timeout', '30s'))
+            {% elif model == 'confirmed_blocks' %}
+                'eth_getBlockByNumber',
+                'params', ARRAY_CONSTRUCT(utils.udf_int_to_hex(block_number), FALSE)
+            {% endif %}
+        ),
         '{{ vault_secret_path }}'
     ) AS request
-        FROM
-            {% if model != 'confirmed_blocks' %}
-                ready_blocks
-            {% else %}
-                to_do
-            {% endif %}
-        {{ order_by_clause }}
-        {% if query_limit %}
-        LIMIT
-            {{ query_limit }} 
-        {% endif %}
+FROM
+    {% if model != 'confirmed_blocks' %}
+        ready_blocks
+    {% else %}
+        to_do
+    {% endif %}
+{{ order_by_clause }}
+{% if query_limit %}
+    LIMIT {{ query_limit }} 
+{% endif %}
+
 {% endmacro %}

--- a/macros/streamline/silver/core/streamline_core_requests.sql
+++ b/macros/streamline/silver/core/streamline_core_requests.sql
@@ -37,7 +37,6 @@ SELECT
         resp :data :result :: STRING
     ) AS block_number
 {% endmacro %}
-
 {% macro streamline_core_requests(
     model_type,
     model,
@@ -46,7 +45,8 @@ SELECT
     query_limit,
     api_url='{service}/{Authentication}',
     order_by_clause='ORDER BY partition_key ASC',
-    new_build = false
+    new_build=false,
+    testing_limit=none
 ) %}
 
 WITH 
@@ -72,7 +72,7 @@ to_do AS (
         block_number IS NOT NULL
         {% if not new_build %}
         AND block_number
-        {% if model_type == 'realtime' %}>={% elif model_type == 'history' %}<={% endif %}
+            {% if model_type == 'realtime' %}>={% elif model_type == 'history' %}<={% endif %}
             (SELECT block_number FROM last_3_days)
         {% endif %}
         {% if model == 'confirmed_blocks' and not new_build %}
@@ -136,6 +136,9 @@ to_do AS (
                 {% endif %}
             )
         {% endif %}
+        {% if testing_limit is not none %}
+        LIMIT {{ testing_limit }}
+        {% endif %}
     )
 {% endif %}
 
@@ -181,7 +184,7 @@ FROM
     {% endif %}
 {{ order_by_clause }}
 {% if query_limit %}
-    LIMIT {{ query_limit }} 
+LIMIT {{ query_limit }} 
 {% endif %}
 
 {% endmacro %}

--- a/macros/streamline/silver/core/streamline_core_requests.sql
+++ b/macros/streamline/silver/core/streamline_core_requests.sql
@@ -44,10 +44,10 @@ SELECT
     quantum_state,
     vault_secret_path,
     query_limit,
+    testing_limit,
     api_url='{Service}/{Authentication}',
     order_by_clause='ORDER BY partition_key ASC',
-    new_build=false,
-    testing_limit=none
+    new_build=false
 ) %}
 
 WITH 
@@ -133,8 +133,9 @@ to_do AS (
                 {% endif %}
             )
         {% endif %}
-        {% if testing_limit is not none %}
-        LIMIT {{ testing_limit }}
+
+        {% if testing_limit %}
+        LIMIT {{ testing_limit }} 
         {% endif %}
     )
 {% endif %}

--- a/macros/streamline/silver/core/streamline_core_requests.sql
+++ b/macros/streamline/silver/core/streamline_core_requests.sql
@@ -76,7 +76,7 @@ to_do AS (
             {% if model_type == 'realtime' %}>={% elif model_type == 'history' %}<={% endif %}
             (SELECT block_number FROM last_3_days)
         {% endif %}
-        {% if model == 'confirmed_blocks' and not new_build %}
+        {% if model == 'confirmed_blocks' %}
             AND block_number <= (SELECT block_number FROM look_back)
         {% endif %}
 

--- a/macros/streamline/silver/core/streamline_core_requests.sql
+++ b/macros/streamline/silver/core/streamline_core_requests.sql
@@ -37,6 +37,7 @@ SELECT
         resp :data :result :: STRING
     ) AS block_number
 {% endmacro %}
+
 {% macro streamline_core_requests(
     model_type,
     model,

--- a/macros/utilities/range_sequence.sql
+++ b/macros/utilities/range_sequence.sql
@@ -10,7 +10,7 @@ FROM
     TABLE(GENERATOR(rowcount => {{ max_num }}))
 {% endmacro %}
 
-{% macro block_sequence() %}
+{% macro block_sequence(min_block=0) %}
 SELECT
     _id AS block_number,
     utils.udf_int_to_hex(_id) AS block_number_hex
@@ -28,6 +28,7 @@ WHERE
         FROM
             {{ ref("streamline__get_chainhead") }}
     )
+    and _id >= {{ min_block }}
 ORDER BY
     _id ASC
 {% endmacro %}

--- a/macros/utilities/range_sequence.sql
+++ b/macros/utilities/range_sequence.sql
@@ -19,7 +19,7 @@ FROM
         'silver__number_sequence'
     ) }}
 WHERE
-    _id <= (
+    _id BETWEEN {{ min_block }} AND (
         SELECT
             COALESCE(
                 block_number,
@@ -28,7 +28,6 @@ WHERE
         FROM
             {{ ref("streamline__get_chainhead") }}
     )
-    and _id >= {{ min_block }}
 ORDER BY
     _id ASC
 {% endmacro %}


### PR DESCRIPTION
- simplifies `streamline_core_complete` macro 
- uses `Service` as the default in `streamline_core_chainhead` macro instead of `service` - we should not continue to use a bad standard here. This is technically a breaking change for ETH but since it is the only one using it I am not sure if a `2.0.0` is worthy... 
- adds `new_build` (bool) and `testing_limit` (int) params to `streamline_core_requests`
- `new_build` (default `false`) ignores lookback and retry logic
- `testing_limit` (default `none`) passes in a limit to the `ready_blocks` CTE in order to not invoke LQ on too many rows. I only imagine this will ever be used in dev for new chains
- some simplifications to logic for complete tables in `streamline_core_requests`
- adds a `min_block` (default 0) param to `block_sequence` to allow for new chain start up without looking at the whole chain
- `adds` a `sei_traces_mode` param to the gold and silver traces macros to handle `tx_hash` vs. `tx_position` discrepancies with SEI EVM 