### PR TITLE
Add tx status bool mode

### DIFF
--- a/macros/core/gold/core_traces.sql
+++ b/macros/core/gold/core_traces.sql
@@ -5,7 +5,8 @@
         uses_overflow_steps = false,
         arb_traces_mode = false,
         schema_name = 'silver',
-        sei_traces_mode = false
+        sei_traces_mode = false,
+        berachain_traces_mode = false
     ) %}
     WITH silver_traces AS (
         SELECT
@@ -578,11 +579,15 @@ aggregated_errors AS (
                             f.traces_id,
                             f.trace_succeeded,
                             f.trace_address,
+                            {% if berachain_traces_mode %}
+                            t.tx_status AS tx_succeeded
+                            {% else %}
                             IFF(
                                 t.tx_status = 'SUCCESS',
                                 TRUE,
                                 FALSE
                             ) AS tx_succeeded
+                            {% endif %}
 
                             {% if arb_traces_mode %},
                             f.before_evm_transfers,
@@ -658,12 +663,15 @@ heal_missing_data AS (
         t.fact_traces_id AS traces_id,
         t.trace_succeeded,
         t.trace_address,
+        {% if berachain_traces_mode %}
+            txs.tx_status AS tx_succeeded
+        {% else %}
         IFF(
             txs.tx_status = 'SUCCESS',
             TRUE,
             FALSE
         ) AS tx_succeeded
-
+        {% endif %}
         {% if arb_traces_mode %},
         t.before_evm_transfers,
         t.after_evm_transfers

--- a/macros/core/gold/core_traces.sql
+++ b/macros/core/gold/core_traces.sql
@@ -6,7 +6,7 @@
         arb_traces_mode = false,
         schema_name = 'silver',
         sei_traces_mode = false,
-        berachain_traces_mode = false
+        tx_status_bool = false
     ) %}
     WITH silver_traces AS (
         SELECT
@@ -579,7 +579,7 @@ aggregated_errors AS (
                             f.traces_id,
                             f.trace_succeeded,
                             f.trace_address,
-                            {% if berachain_traces_mode %}
+                            {% if tx_status_bool %}
                             t.tx_status AS tx_succeeded
                             {% else %}
                             IFF(
@@ -663,7 +663,7 @@ heal_missing_data AS (
         t.fact_traces_id AS traces_id,
         t.trace_succeeded,
         t.trace_address,
-        {% if berachain_traces_mode %}
+        {% if tx_status_bool %}
             txs.tx_status AS tx_succeeded
         {% else %}
         IFF(


### PR DESCRIPTION
- adds a `tx_status_bool` param to `gold_traces_v1` to allow for usage of `tx_status` from `transactions` as a boolean - only applicable to Kaia and Berachain, and will be deprecated in the future 
- will launch with `v.1.10.0`