### PR TITLE
AN-5710/bronze-updates

### DIFF
--- a/models/main_package/core/bronze/streamline/bronze__receipts_fr.sql
+++ b/models/main_package/core/bronze/streamline/bronze__receipts_fr.sql
@@ -19,7 +19,14 @@ UNION ALL
 SELECT
     _partition_by_block_id AS partition_key,
     block_number,
-    VALUE :"array_index" :: INT AS array_index,
+    COALESCE(
+          VALUE :"array_index" :: INT,
+          TRY_TO_NUMBER(
+              utils.udf_hex_to_int(
+                  VALUE :"data" :"transactionIndex" :: STRING
+              )
+          )
+      ) AS array_index,
     VALUE,
     DATA,
     metadata,

--- a/models/main_package/core/bronze/streamline/bronze__traces_fr_v1.sql
+++ b/models/main_package/core/bronze/streamline/bronze__traces_fr_v1.sql
@@ -1,5 +1,5 @@
 {# Set variables #}
-{% set source_name = 'TRACES' %}
+{% set source_name = 'DEBUG_TRACEBLOCKBYNUMBER' if var('GLOBAL_USES_SINGLE_FLIGHT_METHOD',false) else 'TRACES' %}
 {% set source_version = '' %}
 {% set model_type = 'FR' %}
 

--- a/models/main_package/core/streamline/streamline__blocks.sql
+++ b/models/main_package/core/streamline/streamline__blocks.sql
@@ -16,10 +16,14 @@
 ) }}
 
 SELECT
-    _id AS block_number,
-    utils.udf_int_to_hex(_id) AS block_number_hex
+    _id,
+    (
+        ({{ var('GLOBAL_BLOCKS_PER_HOUR',0) }} / 60) * {{ var('GLOBAL_CHAINHEAD_DELAY',3) }}
+    ) :: INT AS block_number_delay, --minute-based block delay
+    (_id - block_number_delay) :: INT AS block_number,
+    utils.udf_int_to_hex(block_number) AS block_number_hex
 FROM
-    {{ ref('utils__number_sequence') }}
+    {{ ref('silver__number_sequence') }}
 WHERE
     _id <= (
         SELECT
@@ -30,4 +34,3 @@ WHERE
         FROM
             {{ ref("streamline__get_chainhead") }}
     )
-    and _id > 0

--- a/models/sources.yml
+++ b/models/sources.yml
@@ -20,6 +20,7 @@ sources:
       - name: receipts_v2
       - name: traces
       - name: traces_v2
+      - name: debug_traceblockbynumber
       - name: confirm_blocks
       - name: confirm_blocks_v2
       - name: decoded_logs


### PR DESCRIPTION
1. Adds support for debug_trace method, tx/array_index, minute based block delays for compatibility with avax, base, polygon etc. streamline v1 integrations
2. Addresses Issue #79 
3. Requires new version tag