### PR TITLE
Update table references to use fsc_evm package in livequery

### DIFF
--- a/models/main_package/core/gold/core__ez_native_transfers.sql
+++ b/models/main_package/core/gold/core__ez_native_transfers.sql
@@ -63,7 +63,7 @@ WITH base AS (
         SYSDATE() AS inserted_timestamp,
         SYSDATE() AS modified_timestamp
     FROM
-        {{ ref('core__fact_traces') }}
+        {{ ref('fsc_evm', 'core__fact_traces') }}
         tr
         LEFT JOIN {{ ref('price__ez_prices_hourly') }}
         ON DATE_TRUNC(

--- a/models/main_package/core/gold/core__ez_token_transfers.sql
+++ b/models/main_package/core/gold/core__ez_token_transfers.sql
@@ -79,7 +79,7 @@ WITH base AS (
         SYSDATE() AS inserted_timestamp,
         SYSDATE() AS modified_timestamp
     FROM
-        {{ ref('core__fact_event_logs') }}
+        {{ ref('fsc_evm', 'core__fact_event_logs') }}
         f
         LEFT JOIN {{ ref('price__ez_prices_hourly') }}
         p

--- a/models/main_package/core/gold/core__fact_event_logs.sql
+++ b/models/main_package/core/gold/core__fact_event_logs.sql
@@ -106,7 +106,7 @@ new_logs AS (
         l.tx_succeeded
     FROM
         flattened_logs l
-        LEFT JOIN {{ ref('core__fact_blocks') }}
+        LEFT JOIN {{ ref('fsc_evm', 'core__fact_blocks') }}
         b
         ON l.block_number = b.block_number
 
@@ -118,7 +118,7 @@ AND b.modified_timestamp >= (
         {{ this }}
 )
 {% endif %}
-LEFT JOIN {{ ref('core__fact_transactions') }}
+LEFT JOIN {{ ref('fsc_evm', 'core__fact_transactions') }}
 txs
 ON l.tx_hash = txs.tx_hash
 AND l.block_number = txs.block_number
@@ -156,11 +156,11 @@ missing_data AS (
     FROM
         {{ this }}
         t
-        LEFT JOIN {{ ref('core__fact_transactions') }}
+        LEFT JOIN {{ ref('fsc_evm', 'core__fact_transactions') }}
         txs
         ON t.tx_hash = txs.tx_hash
         AND t.block_number = txs.block_number
-        LEFT JOIN {{ ref('core__fact_blocks') }}
+        LEFT JOIN {{ ref('fsc_evm', 'core__fact_blocks') }}
         b
         ON t.block_number = b.block_number
     WHERE

--- a/models/main_package/core/gold/core__fact_traces.sql
+++ b/models/main_package/core/gold/core__fact_traces.sql
@@ -44,7 +44,7 @@
     cluster_by = ['block_timestamp::DATE'],
     incremental_predicates = [fsc_evm.standard_predicate()],
     tags = ['gold_core']
-) }}    
+) }}
 
 {% endif %}
 
@@ -595,7 +595,7 @@ aggregated_errors AS (
                         {% endif %}
                         FROM
                             json_traces f
-                            LEFT OUTER JOIN {{ ref('core__fact_transactions') }}
+                            LEFT OUTER JOIN {{ ref('fsc_evm', 'core__fact_transactions') }}
                             t
                             ON {% if TRACES_SEI_MODE %}
                                 f.tx_hash = t.tx_hash
@@ -669,7 +669,7 @@ heal_missing_data AS (
     FROM
         {{ this }}
         t
-        JOIN {{ ref('core__fact_transactions') }}
+        JOIN {{ ref('fsc_evm', 'core__fact_transactions') }}
         txs
         {% if TRACES_SEI_MODE %}
             ON t.tx_hash = txs.tx_hash

--- a/models/main_package/core/gold/core__fact_transactions.sql
+++ b/models/main_package/core/gold/core__fact_transactions.sql
@@ -292,7 +292,7 @@ WHERE
             txs.v
         FROM
             transactions_fields txs
-            LEFT JOIN {{ ref('core__fact_blocks') }}
+            LEFT JOIN {{ ref('fsc_evm', 'core__fact_blocks') }}
             b
             ON txs.block_number = b.block_number
 
@@ -406,7 +406,7 @@ missing_data AS (
         utils.udf_decimal_adjust(
             t.gas_price * utils.udf_hex_to_int(
                 r.receipts_json :gasUsed :: STRING
-            ) :: bigint, 
+            ) :: bigint,
             9
         ) AS tx_fee_precise_heal,
         {% endif %}
@@ -443,7 +443,7 @@ missing_data AS (
     FROM
         {{ this }}
         t
-        LEFT JOIN {{ ref('core__fact_blocks') }}
+        LEFT JOIN {{ ref('fsc_evm', 'core__fact_blocks') }}
         b
         ON t.block_number = b.block_number
         LEFT JOIN {{ ref('silver__receipts') }}


### PR DESCRIPTION
This PR adds `fsc_evm` on the core logics so that livequery are able to correctly reference to the specific core logic from near or other packages as well.