### PR TITLE
add/async-request-param

### DIFF
--- a/macros/main_package/streamline/set_streamline_parameters.sql
+++ b/macros/main_package/streamline/set_streamline_parameters.sql
@@ -44,9 +44,9 @@
     "method_params": rpc_config['method_params']
 } -%}
 
-{%- set async_requests_var = (model_name ~ '_' ~ model_type ~ '_async_concurrent_requests').upper() -%}
-{%- if var(async_requests_var, none) is not none -%}
-    {%- do params.update({"async_concurrent_requests": var(async_requests_var)}) -%}
+{%- set async_concurrent_requests = (model_name ~ '_' ~ model_type ~ '_async_concurrent_requests').upper() -%}
+{%- if var(async_concurrent_requests, none) is not none -%}
+    {%- do params.update({"async_concurrent_requests": var(async_concurrent_requests)}) -%}
 {%- endif -%}
 
 {%- if rpc_config.get('exploded_key') is not none -%}

--- a/macros/main_package/streamline/set_streamline_parameters.sql
+++ b/macros/main_package/streamline/set_streamline_parameters.sql
@@ -44,6 +44,11 @@
     "method_params": rpc_config['method_params']
 } -%}
 
+{%- set async_requests_var = (model_name ~ '_' ~ model_type ~ '_async_concurrent_requests').upper() -%}
+{%- if var(async_requests_var, none) is not none -%}
+    {%- do params.update({"async_concurrent_requests": var(async_requests_var)}) -%}
+{%- endif -%}
+
 {%- if rpc_config.get('exploded_key') is not none -%}
     {%- do params.update({"exploded_key": tojson(rpc_config['exploded_key'])}) -%}
 {%- endif -%}


### PR DESCRIPTION
1. Adds an optional async concurrent requests param to core streamline calls
2. Requires new version tag