### PR TITLE
AN-5839/fsc-evm-v4-tags

### DIFF
--- a/macros/tags/model_tags/get_tags.sql
+++ b/macros/tags/model_tags/get_tags.sql
@@ -34,8 +34,6 @@
         {% do tags.append(filename) %}
     {% endif %}
     
-    {% do tags.append(clean_filename) %}
-    
     {# Add any additional tags provided #}
     {% if additional_tags is not none %}
         {% do tags.extend(additional_tags) %}

--- a/macros/tags/model_tags/get_tags.sql
+++ b/macros/tags/model_tags/get_tags.sql
@@ -1,60 +1,42 @@
 {%- macro load_tag_mapping() -%}
     {% set tag_mapping = get_tag_dictionary() %}
-    {{ log("Loaded tag mappings: " ~ tag_mapping, info=True) }}
     {{ return(tag_mapping) }}
 {%- endmacro -%}
 
-{%- macro get_path_tags(model, additional_tags=[]) -%}
+{%- macro get_path_tags(model) -%}
     {% set tags = [] %}
 
-    {{ log(model.original_file_path, info=True) }}
-    
     {% set path_str = model.original_file_path | string %}
     {% set path = path_str.split('/') %}
-    
+
     {# Skip 'models' directory if it exists #}
     {% set start_index = 1 if path[0] == 'models' else 0 %}
-    
+
     {# Process each directory in the path #}
     {% for part in path[start_index:-1] %}
         {% do tags.append(part) %}
     {% endfor %}
-    
+
     {# Process the filename without extension #}
     {% set filename = path[-1] | replace('.sql', '') | replace('.yml', '') %}
-    
-    {# Split on __ and take the last part as the model name #}
-    {% set name_parts = filename.split('__') %}
-    {% if name_parts|length > 1 %}
-        {# Add the prefix as a tag #}
-        {% do tags.append(name_parts[0]) %}
-        {# Add the actual model name #}
-        {% do tags.append(name_parts[-1]) %}
-    {% else %}
-        {% do tags.append(filename) %}
-    {% endif %}
-    
-    {# Add any additional tags provided #}
-    {% if additional_tags is not none %}
-        {% do tags.extend(additional_tags) %}
-    {% endif %}
-    
-    {{ log("Initial tags: " ~ tags, info=True) }}
-    
+
+    {# Add the full filename as a tag #}
+    {% do tags.append(filename) %}
+
     {# Load tag mapping from YAML #}
     {% set tag_mapping = load_tag_mapping() %}
-    
+
     {# Apply tag mapping rules #}
     {% set final_tags = tags.copy() %}
     {% for tag in tags %}
         {% if tag in tag_mapping %}
             {% do final_tags.extend(tag_mapping[tag]) %}
-            {{ log("Added tags from '" ~ tag ~ "': " ~ tag_mapping[tag], info=True) }}
         {% endif %}
     {% endfor %}
-    
-    {{ log("Final tags: " ~ final_tags | unique | list, info=True) }}
-    
+
+    {# Add tags as a comment in the compiled SQL #}
+    {{ "-- Auto-generated tags: " ~ (final_tags | unique | list | join(', ')) }}
+
     {# Return unique tags to avoid duplicates #}
     {{ return(final_tags | unique | list) }}
 {%- endmacro -%}

--- a/macros/tags/model_tags/tag_mapping.sql
+++ b/macros/tags/model_tags/tag_mapping.sql
@@ -1,0 +1,12 @@
+{#
+    Sets folder level tags, which will be inherited by all models in that folder
+#}
+{%- macro get_tag_dictionary() -%}
+    {% set tag_mapping = {
+        
+        'defi': ['curated', 'reorg'],
+        'protocols': ['curated', 'reorg']
+    } %}
+    
+    {{ return(tag_mapping) }}
+{%- endmacro -%}

--- a/macros/tests/dynamic_tests.sql
+++ b/macros/tests/dynamic_tests.sql
@@ -32,7 +32,7 @@
         filter_condition = none
     ) -%}
 
-    {% if where %}
+        {% if where and interval_vars.interval_type is not none and interval_vars.interval_value is not none %}
         {% if "__timestamp_filter__" in where %}
             {% set columns = adapter.get_columns_in_relation(relation) %}
             {% set column_names = columns | map(attribute='name') | list %}

--- a/macros/utils/get_path_tags.sql
+++ b/macros/utils/get_path_tags.sql
@@ -1,0 +1,30 @@
+{%- macro get_path_tags(model_name, additional_tags=[]) -%}
+    {% set tags = [] %}
+    
+    {# Get the full path from the model name #}
+    {% set path = model_name.split('/') %}
+    
+    {# Skip 'models' directory if it exists #}
+    {% set start_index = 1 if path[0] == 'models' else 0 %}
+    
+    {# Process each directory in the path #}
+    {% for part in path[start_index:-1] %}  {# -1 to exclude the filename #}
+        {% do tags.append(part) %}
+    {% endfor %}
+    
+    {# Process the filename without extension #}
+    {% set filename = path[-1] | replace('.sql', '') | replace('.yml', '') %}
+    
+    {# Remove prefixes like bronze__, silver__, gold__, core__ #}
+    {% set clean_filename = filename | replace('bronze__', '') | replace('silver__', '') | replace('gold__', '') | replace('core__', '') %}
+    
+    {% do tags.append(clean_filename) %}
+    
+    {# Add any additional tags provided #}
+    {% if additional_tags is not none %}
+        {% do tags.extend(additional_tags) %}
+    {% endif %}
+    
+    {# Return unique tags to avoid duplicates #}
+    {{ return(tags | unique | list) }}
+{%- endmacro -%} 

--- a/makefile
+++ b/makefile
@@ -1,5 +1,3 @@
-.PHONY: new_repo_tag
-
 new_repo_tag:
 	@echo "Last 3 tags:"
 	@git tag -l --sort=-v:refname | head -n 3
@@ -27,3 +25,12 @@ new_repo_tag:
 	else \
 		echo "No tag name entered. Operation cancelled."; \
 	fi
+copy-selectors:
+	@if [ -f dbt_packages/fsc_evm/selectors.yml ]; then \
+		cp dbt_packages/fsc_evm/selectors.yml ./selectors.yml && \
+		echo "Successfully copied selectors.yml to project root"; \
+	else \
+		echo "Error: dbt_packages/fsc_evm/selectors.yml not found"; \
+		exit 1; \
+	fi
+.PHONY: new_repo_tag copy-selectors

--- a/makefile
+++ b/makefile
@@ -33,4 +33,19 @@ copy-selectors:
 		echo "Error: dbt_packages/fsc_evm/selectors.yml not found"; \
 		exit 1; \
 	fi
-.PHONY: new_repo_tag copy-selectors
+append-selectors:
+	@if [ -f dbt_packages/fsc_evm/selectors.yml ] && [ -f selectors.yml ]; then \
+		echo "Merging selectors..."; \
+		awk 'BEGIN {p=1} \
+			/^selectors:/ {if(p==1) {print; p=0; next}} \
+			p==1 {print} \
+			/^selectors:/ {p=0; next} \
+			p==0 {print}' selectors.yml > selectors_temp.yml && \
+		awk '/^selectors:/ {next} {print}' dbt_packages/fsc_evm/selectors.yml >> selectors_temp.yml && \
+		mv selectors_temp.yml selectors.yml && \
+		echo "Successfully merged selectors"; \
+	else \
+		echo "Error: One or both selector files not found"; \
+		exit 1; \
+	fi
+.PHONY: new_repo_tag copy-selectors append-selectors

--- a/models/curated_package/protocols/vertex/gold/vertex__ez_account_stats.sql
+++ b/models/curated_package/protocols/vertex/gold/vertex__ez_account_stats.sql
@@ -5,7 +5,7 @@
     materialized = 'view',
     meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'CLOB, DEX, STATS',
     } } },
-    tags = ['curated', 'gold_vertex']
+    tags = get_path_tags(model)
 ) }}
 
 SELECT

--- a/models/curated_package/protocols/vertex/gold/vertex__ez_clearing_house_events.sql
+++ b/models/curated_package/protocols/vertex/gold/vertex__ez_clearing_house_events.sql
@@ -6,7 +6,7 @@
     unique_key = 'ez_clearing_house_events_id',
     merge_exclude_columns = ["inserted_timestamp"],
     post_hook = "ALTER TABLE {{ this }} ADD SEARCH OPTIMIZATION ON EQUALITY(trader, symbol, subaccount), SUBSTRING(subaccount, symbol)",
-    tags = ['curated', 'gold_vertex']
+    tags = get_path_tags(model)
 ) }}
 
 SELECT

--- a/models/curated_package/protocols/vertex/gold/vertex__ez_edge_trades.sql
+++ b/models/curated_package/protocols/vertex/gold/vertex__ez_edge_trades.sql
@@ -6,7 +6,7 @@
     unique_key = 'ez_edge_trades_id',
     merge_exclude_columns = ["inserted_timestamp"],
     post_hook = "ALTER TABLE {{ this }} ADD SEARCH OPTIMIZATION ON EQUALITY(trader, symbol, subaccount), SUBSTRING(subaccount, symbol)",
-    tags = ['curated', 'gold_vertex']
+    tags = get_path_tags(model)
 ) }}
 
 SELECT

--- a/models/curated_package/protocols/vertex/gold/vertex__ez_liquidations.sql
+++ b/models/curated_package/protocols/vertex/gold/vertex__ez_liquidations.sql
@@ -6,7 +6,7 @@
     unique_key = 'ez_liquidations_id',
     merge_exclude_columns = ["inserted_timestamp"],
     post_hook = "ALTER TABLE {{ this }} ADD SEARCH OPTIMIZATION ON EQUALITY(trader, subaccount,digest), SUBSTRING(subaccount,trader)",
-    tags = ['curated', 'gold_vertex']
+    tags = get_path_tags(model)
 ) }}
 
 SELECT

--- a/models/curated_package/protocols/vertex/gold/vertex__ez_market_depth_stats.sql
+++ b/models/curated_package/protocols/vertex/gold/vertex__ez_market_depth_stats.sql
@@ -6,7 +6,7 @@
     unique_key = 'ez_market_depth_stats_id',
     merge_exclude_columns = ["inserted_timestamp"],
     post_hook = "ALTER TABLE {{ this }} ADD SEARCH OPTIMIZATION ON EQUALITY(ticker_id,product_id), SUBSTRING(ticker_id,product_id)",
-    tags = ['curated', 'gold_vertex']
+    tags = get_path_tags(model)
 ) }}
 
 SELECT

--- a/models/curated_package/protocols/vertex/gold/vertex__ez_market_stats.sql
+++ b/models/curated_package/protocols/vertex/gold/vertex__ez_market_stats.sql
@@ -6,7 +6,7 @@
     unique_key = 'ez_market_stats_id',
     merge_exclude_columns = ["inserted_timestamp"],
     post_hook = "ALTER TABLE {{ this }} ADD SEARCH OPTIMIZATION ON EQUALITY(ticker_id,product_id,symbol), SUBSTRING(ticker_id,product_id,symbol)",
-    tags = ['curated', 'gold_vertex']
+    tags = get_path_tags(model)
 ) }}
 
 SELECT

--- a/models/curated_package/protocols/vertex/gold/vertex__ez_money_markets.sql
+++ b/models/curated_package/protocols/vertex/gold/vertex__ez_money_markets.sql
@@ -6,7 +6,7 @@
     unique_key = 'ez_money_markets_id',
     merge_exclude_columns = ["inserted_timestamp"],
     post_hook = "ALTER TABLE {{ this }} ADD SEARCH OPTIMIZATION ON EQUALITY(ticker_id,product_id,symbol), SUBSTRING(ticker_id,product_id,symbol)",
-    tags = ['curated', 'gold_vertex']
+    tags = get_path_tags(model)
 ) }}
 
 SELECT

--- a/models/curated_package/protocols/vertex/gold/vertex__ez_perp_trades.sql
+++ b/models/curated_package/protocols/vertex/gold/vertex__ez_perp_trades.sql
@@ -6,7 +6,7 @@
     unique_key = 'ez_perp_trades_id',
     merge_exclude_columns = ["inserted_timestamp"],
     post_hook = "ALTER TABLE {{ this }} ADD SEARCH OPTIMIZATION ON EQUALITY(tx_hash,symbol,trader,digest,subaccount), SUBSTRING(symbol,trader)",
-    tags = ['curated', 'gold_vertex']
+    tags = get_path_tags(model)
 ) }}
 
 

--- a/models/curated_package/protocols/vertex/gold/vertex__ez_spot_trades.sql
+++ b/models/curated_package/protocols/vertex/gold/vertex__ez_spot_trades.sql
@@ -6,7 +6,7 @@
     unique_key = 'ez_spot_trades_id',
     merge_exclude_columns = ["inserted_timestamp"],
     post_hook = "ALTER TABLE {{ this }} ADD SEARCH OPTIMIZATION ON EQUALITY(tx_hash,symbol,trader,digest,subaccount), SUBSTRING(symbol,trader)",
-    tags = ['curated', 'gold_vertex']
+    tags = get_path_tags(model)
 ) }}
 
 SELECT

--- a/models/curated_package/protocols/vertex/silver/silver__vertex_account_stats.sql
+++ b/models/curated_package/protocols/vertex/silver/silver__vertex_account_stats.sql
@@ -5,7 +5,7 @@
     materialized = 'incremental',
     incremental_strategy = 'delete+insert',
     unique_key = 'subaccount',
-    tags = 'curated'
+    tags = get_path_tags(model)
 ) }}
 
 WITH

--- a/models/curated_package/protocols/vertex/silver/silver__vertex_collateral.sql
+++ b/models/curated_package/protocols/vertex/silver/silver__vertex_collateral.sql
@@ -10,7 +10,7 @@
     incremental_strategy = 'delete+insert',
     unique_key = 'fact_event_logs_id',
     cluster_by = ['block_timestamp::DATE'],
-    tags = ['curated','reorg'],
+    tags = get_path_tags(model),
     enabled = false
 ) }}
 

--- a/models/curated_package/protocols/vertex/silver/silver__vertex_dim_products.sql
+++ b/models/curated_package/protocols/vertex/silver/silver__vertex_dim_products.sql
@@ -6,7 +6,7 @@
     incremental_strategy = 'delete+insert',
     unique_key = 'product_id',
     cluster_by = ['block_timestamp::DATE'],
-    tags = ['curated','reorg']
+    tags = get_path_tags(model)
 ) }}
 
 

--- a/models/curated_package/protocols/vertex/silver/silver__vertex_edge_trades.sql
+++ b/models/curated_package/protocols/vertex/silver/silver__vertex_edge_trades.sql
@@ -6,7 +6,7 @@
     incremental_strategy = 'delete+insert',
     unique_key = 'fact_event_logs_id',
     cluster_by = ['block_timestamp::DATE'],
-    tags = ['curated','reorg']
+    tags = get_path_tags(model)
 ) }}
 
 

--- a/models/curated_package/protocols/vertex/silver/silver__vertex_liquidations.sql
+++ b/models/curated_package/protocols/vertex/silver/silver__vertex_liquidations.sql
@@ -9,7 +9,7 @@
     incremental_strategy = 'delete+insert',
     unique_key = 'fact_event_logs_id',
     cluster_by = ['block_timestamp::DATE'],
-    tags = ['curated','reorg']
+    tags = get_path_tags(model)
 ) }}
 
 

--- a/models/curated_package/protocols/vertex/silver/silver__vertex_market_stats.sql
+++ b/models/curated_package/protocols/vertex/silver/silver__vertex_market_stats.sql
@@ -6,7 +6,7 @@
     incremental_strategy = 'merge',
     unique_key = ['ticker_id','hour'],
     cluster_by = ['HOUR::DATE'],
-    tags = 'curated'
+    tags = get_path_tags(model)
 ) }}
 
 

--- a/models/curated_package/protocols/vertex/silver/silver__vertex_money_markets.sql
+++ b/models/curated_package/protocols/vertex/silver/silver__vertex_money_markets.sql
@@ -6,7 +6,7 @@
     incremental_strategy = 'merge',
     unique_key = ['ticker_id','hour'],
     cluster_by = ['HOUR::DATE'],
-    tags = 'curated'
+    tags = get_path_tags(model)
 ) }}
 
 

--- a/models/curated_package/protocols/vertex/silver/silver__vertex_perps.sql
+++ b/models/curated_package/protocols/vertex/silver/silver__vertex_perps.sql
@@ -9,7 +9,7 @@
     incremental_strategy = 'delete+insert',
     unique_key = 'fact_event_logs_id',
     cluster_by = ['block_timestamp::DATE'],
-    tags = ['curated','reorg']
+    tags = get_path_tags(model)
 ) }}
 
 

--- a/models/curated_package/protocols/vertex/silver/silver__vertex_spot.sql
+++ b/models/curated_package/protocols/vertex/silver/silver__vertex_spot.sql
@@ -9,7 +9,7 @@
     incremental_strategy = 'delete+insert',
     unique_key = 'fact_event_logs_id',
     cluster_by = ['block_timestamp::DATE'],
-    tags = ['curated','reorg']
+    tags = get_path_tags(model)
 ) }}
 
 

--- a/models/curated_package/stats/gold/stats__ez_core_metrics_hourly.sql
+++ b/models/curated_package/stats/gold/stats__ez_core_metrics_hourly.sql
@@ -9,7 +9,7 @@
     materialized = 'view',
     meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'STATS, METRICS, CORE, HOURLY',
     } } },
-    tags = ['curated', 'gold_stats']
+    tags = get_path_tags(model)
 ) }}
 
 {# Main query starts here #}

--- a/models/curated_package/stats/silver/silver_stats__core_metrics_hourly.sql
+++ b/models/curated_package/stats/silver/silver_stats__core_metrics_hourly.sql
@@ -7,7 +7,7 @@
     incremental_strategy = 'delete+insert',
     unique_key = "block_timestamp_hour",
     cluster_by = ['block_timestamp_hour::DATE'],
-    tags = ['curated', 'silver_stats', 'daily_test']
+    tags = get_path_tags(model)
 ) }}
 
 {# run incremental timestamp value first then use it as a static value #}

--- a/models/decoder_package/abis/bronze/bronze_api__contract_abis.sql
+++ b/models/decoder_package/abis/bronze/bronze_api__contract_abis.sql
@@ -16,7 +16,7 @@
     unique_key = "contract_address",
     post_hook = "ALTER TABLE {{ this }} ADD SEARCH OPTIMIZATION on equality(contract_address)",
     full_refresh = false,
-    tags = ['bronze_abis']
+    tags = get_path_tags(model)
 ) }}
 
 {% else %}
@@ -25,7 +25,7 @@
     materialized = 'incremental',
     unique_key = "contract_address",
     post_hook = "ALTER TABLE {{ this }} ADD SEARCH OPTIMIZATION on equality(contract_address)",
-    tags = ['bronze_abis']
+    tags = get_path_tags(model)
 ) }}
 
 {% endif %}

--- a/models/decoder_package/abis/bronze/tests/test_bronze__contract_abis_full.sql
+++ b/models/decoder_package/abis/bronze/tests/test_bronze__contract_abis_full.sql
@@ -3,7 +3,7 @@
 
 {{ config (
     materialized = "view",
-    tags = ['full_test']
+    tags = get_path_tags(model)
 ) }}
 
 SELECT

--- a/models/decoder_package/abis/bronze/tests/test_bronze__contract_abis_recent.sql
+++ b/models/decoder_package/abis/bronze/tests/test_bronze__contract_abis_recent.sql
@@ -3,7 +3,7 @@
 
 {{ config (
     materialized = "view",
-    tags = ['daily_test']
+    tags = get_path_tags(model)
 ) }}
 
 SELECT

--- a/models/decoder_package/abis/gold/core__dim_contract_abis.sql
+++ b/models/decoder_package/abis/gold/core__dim_contract_abis.sql
@@ -6,7 +6,7 @@
     unique_key = "contract_address",
     merge_exclude_columns = ["inserted_timestamp"],
     post_hook = "ALTER TABLE {{ this }} ADD SEARCH OPTIMIZATION ON EQUALITY(contract_address,bytecode), SUBSTRING(contract_address,bytecode)",
-    tags = ['gold_abis']
+    tags = get_path_tags(model)
 ) }}
 
 SELECT

--- a/models/decoder_package/abis/gold/tests/test_gold__dim_contract_abis_full.sql
+++ b/models/decoder_package/abis/gold/tests/test_gold__dim_contract_abis_full.sql
@@ -3,7 +3,7 @@
 
 {{ config (
     materialized = "view",
-    tags = ['full_test']
+    tags = get_path_tags(model)
 ) }}
 
 SELECT

--- a/models/decoder_package/abis/gold/tests/test_gold__dim_contract_abis_recent.sql
+++ b/models/decoder_package/abis/gold/tests/test_gold__dim_contract_abis_recent.sql
@@ -3,7 +3,7 @@
 
 {{ config (
     materialized = "view",
-    tags = ['daily_test']
+    tags = get_path_tags(model)
 ) }}
 
 SELECT

--- a/models/decoder_package/abis/silver/silver__abis.sql
+++ b/models/decoder_package/abis/silver/silver__abis.sql
@@ -8,7 +8,7 @@
     unique_key = "contract_address",
     merge_exclude_columns = ["inserted_timestamp"],
     post_hook = "ALTER TABLE {{ this }} ADD SEARCH OPTIMIZATION ON EQUALITY(contract_address,abi_hash,bytecode), SUBSTRING(contract_address,abi_hash,bytecode)",
-    tags = ['silver_abis']
+    tags = get_path_tags(model)
 ) }}
 
 WITH verified_abis AS (

--- a/models/decoder_package/abis/silver/silver__bytecode_abis.sql
+++ b/models/decoder_package/abis/silver/silver__bytecode_abis.sql
@@ -4,7 +4,7 @@
 {{ config (
     materialized = "incremental",
     unique_key = "contract_address",
-    tags = ['silver_abis']
+    tags = get_path_tags(model)
 ) }}
 
 WITH contracts_with_abis AS (

--- a/models/decoder_package/abis/silver/silver__complete_event_abis.sql
+++ b/models/decoder_package/abis/silver/silver__complete_event_abis.sql
@@ -6,7 +6,7 @@
     unique_key = ["parent_contract_address","event_signature","start_block"],
     merge_exclude_columns = ["inserted_timestamp"],
     post_hook = "ALTER TABLE {{ this }} ADD SEARCH OPTIMIZATION",
-    tags = ['silver_abis']
+    tags = get_path_tags(model)
 ) }}
 
 WITH new_abis AS (

--- a/models/decoder_package/abis/silver/silver__flat_event_abis.sql
+++ b/models/decoder_package/abis/silver/silver__flat_event_abis.sql
@@ -7,7 +7,7 @@
     unique_key = "contract_address",
     cluster_by = "_inserted_timestamp::date",
     post_hook = "ALTER TABLE {{ this }} ADD SEARCH OPTIMIZATION ON EQUALITY (contract_address)",
-    tags = ['silver_abis']
+    tags = get_path_tags(model)
 ) }}
 
 WITH abi_base AS (

--- a/models/decoder_package/abis/silver/silver__user_verified_abis.sql
+++ b/models/decoder_package/abis/silver/silver__user_verified_abis.sql
@@ -6,7 +6,7 @@
 {{ config (
     materialized = "incremental",
     unique_key = "id",
-    tags = ['silver_abis']
+    tags = get_path_tags(model)
 ) }}
 
 WITH base AS (

--- a/models/decoder_package/abis/silver/silver__verified_abis.sql
+++ b/models/decoder_package/abis/silver/silver__verified_abis.sql
@@ -20,7 +20,7 @@
     unique_key = "contract_address",
     merge_update_columns = ["contract_address"],
     post_hook = "ALTER TABLE {{ this }} ADD SEARCH OPTIMIZATION on equality(contract_address)",
-    tags = ['silver_abis']
+    tags = get_path_tags(model)
 ) }}
 
 WITH base AS (

--- a/models/decoder_package/abis/silver/tests/abis/test_silver__abis_full.sql
+++ b/models/decoder_package/abis/silver/tests/abis/test_silver__abis_full.sql
@@ -3,7 +3,7 @@
 
 {{ config (
     materialized = "view",
-    tags = ['full_test']
+    tags = get_path_tags(model)
 ) }}
 
 SELECT

--- a/models/decoder_package/abis/silver/tests/abis/test_silver__abis_recent.sql
+++ b/models/decoder_package/abis/silver/tests/abis/test_silver__abis_recent.sql
@@ -3,7 +3,7 @@
 
 {{ config (
     materialized = "view",
-    tags = ['daily_test']
+    tags = get_path_tags(model)
 ) }}
 
 SELECT

--- a/models/decoder_package/abis/silver/tests/bytecode_abis/test_silver__bytecode_abis_full.sql
+++ b/models/decoder_package/abis/silver/tests/bytecode_abis/test_silver__bytecode_abis_full.sql
@@ -3,7 +3,7 @@
 
 {{ config (
     materialized = "view",
-    tags = ['full_test']
+    tags = get_path_tags(model)
 ) }}
 
 SELECT

--- a/models/decoder_package/abis/silver/tests/bytecode_abis/test_silver__bytecode_abis_recent.sql
+++ b/models/decoder_package/abis/silver/tests/bytecode_abis/test_silver__bytecode_abis_recent.sql
@@ -3,7 +3,7 @@
 
 {{ config (
     materialized = "view",
-    tags = ['daily_test']
+    tags = get_path_tags(model)
 ) }}
 
 SELECT

--- a/models/decoder_package/abis/silver/tests/event_abis/test_silver__complete_event_abis_full.sql
+++ b/models/decoder_package/abis/silver/tests/event_abis/test_silver__complete_event_abis_full.sql
@@ -3,7 +3,7 @@
 
 {{ config (
     materialized = "view",
-    tags = ['full_test']
+    tags = get_path_tags(model)
 ) }}
 
 SELECT

--- a/models/decoder_package/abis/silver/tests/event_abis/test_silver__complete_event_abis_recent.sql
+++ b/models/decoder_package/abis/silver/tests/event_abis/test_silver__complete_event_abis_recent.sql
@@ -3,7 +3,7 @@
 
 {{ config (
     materialized = "view",
-    tags = ['daily_test']
+    tags = get_path_tags(model)
 ) }}
 
 SELECT

--- a/models/decoder_package/abis/silver/tests/user_verified_abis/test_silver__user_verified_abis_full.sql
+++ b/models/decoder_package/abis/silver/tests/user_verified_abis/test_silver__user_verified_abis_full.sql
@@ -3,7 +3,7 @@
 
 {{ config (
     materialized = "view",
-    tags = ['full_test']
+    tags = get_path_tags(model)
 ) }}
 
 SELECT

--- a/models/decoder_package/abis/silver/tests/user_verified_abis/test_silver__user_verified_abis_recent.sql
+++ b/models/decoder_package/abis/silver/tests/user_verified_abis/test_silver__user_verified_abis_recent.sql
@@ -3,7 +3,7 @@
 
 {{ config (
     materialized = "view",
-    tags = ['daily_test']
+    tags = get_path_tags(model)
 ) }}
 
 SELECT

--- a/models/decoder_package/abis/silver/tests/verified_abis/test_silver__verified_abis_full.sql
+++ b/models/decoder_package/abis/silver/tests/verified_abis/test_silver__verified_abis_full.sql
@@ -3,7 +3,7 @@
 
 {{ config (
     materialized = "view",
-    tags = ['full_test']
+    tags = get_path_tags(model)
 ) }}
 
 SELECT

--- a/models/decoder_package/abis/silver/tests/verified_abis/test_silver__verified_abis_recent.sql
+++ b/models/decoder_package/abis/silver/tests/verified_abis/test_silver__verified_abis_recent.sql
@@ -3,7 +3,7 @@
 
 {{ config (
     materialized = "view",
-    tags = ['daily_test']
+    tags = get_path_tags(model)
 ) }}
 
 SELECT

--- a/models/decoder_package/decoded_logs/bronze/bronze__decoded_logs.sql
+++ b/models/decoder_package/decoded_logs/bronze/bronze__decoded_logs.sql
@@ -13,7 +13,7 @@
 {# Set up dbt configuration #}
 {{ config (
     materialized = 'view',
-    tags = ['bronze_decoded_logs']
+    tags = get_path_tags(model)
 ) }}
 
 {# Main query starts here #}

--- a/models/decoder_package/decoded_logs/bronze/bronze__decoded_logs_fr.sql
+++ b/models/decoder_package/decoded_logs/bronze/bronze__decoded_logs_fr.sql
@@ -4,7 +4,7 @@
 {# Set up dbt configuration #}
 {{ config (
     materialized = 'view',
-    tags = ['bronze_decoded_logs']
+    tags = get_path_tags(model)
 ) }}
 
 SELECT

--- a/models/decoder_package/decoded_logs/bronze/bronze__decoded_logs_fr_v1.sql
+++ b/models/decoder_package/decoded_logs/bronze/bronze__decoded_logs_fr_v1.sql
@@ -13,7 +13,7 @@
 {# Set up dbt configuration #}
 {{ config (
     materialized = 'view',
-    tags = ['bronze_decoded_logs_streamline_v1']
+    tags = get_path_tags(model)
 ) }}
 
 {# Main query starts here #}

--- a/models/decoder_package/decoded_logs/bronze/bronze__decoded_logs_fr_v2.sql
+++ b/models/decoder_package/decoded_logs/bronze/bronze__decoded_logs_fr_v2.sql
@@ -13,7 +13,7 @@
 {# Set up dbt configuration #}
 {{ config (
     materialized = 'view',
-    tags = ['bronze_decoded_logs']
+    tags = get_path_tags(model)
 ) }}
 
 {# Main query starts here #}

--- a/models/decoder_package/decoded_logs/gold/core__ez_decoded_event_logs.sql
+++ b/models/decoder_package/decoded_logs/gold/core__ez_decoded_event_logs.sql
@@ -11,7 +11,7 @@
     incremental_predicates = [fsc_evm.standard_predicate()],
     full_refresh = false,
     post_hook = post_hook,
-    tags = ['gold_decoded_logs']
+    tags = get_path_tags(model)
 ) }}
 
 WITH base AS (

--- a/models/decoder_package/decoded_logs/gold/tests/test_gold__ez_decoded_event_logs_full.sql
+++ b/models/decoder_package/decoded_logs/gold/tests/test_gold__ez_decoded_event_logs_full.sql
@@ -3,7 +3,7 @@
 
 {{ config (
     materialized = "view",
-    tags = ['full_test']
+    tags = get_path_tags(model)
 ) }}
 
 SELECT

--- a/models/decoder_package/decoded_logs/gold/tests/test_gold__ez_decoded_event_logs_recent.sql
+++ b/models/decoder_package/decoded_logs/gold/tests/test_gold__ez_decoded_event_logs_recent.sql
@@ -3,7 +3,7 @@
 
 {{ config (
     materialized = "view",
-    tags = ['recent_test']
+    tags = get_path_tags(model)
 ) }}
 
 SELECT

--- a/models/decoder_package/decoded_logs/silver/silver__decoded_logs.sql
+++ b/models/decoder_package/decoded_logs/silver/silver__decoded_logs.sql
@@ -9,7 +9,7 @@
     cluster_by = ['modified_timestamp::date', 'round(block_number, -3)'],
     incremental_predicates = [fsc_evm.standard_predicate()],
     full_refresh = false,
-    tags = ['silver_decoded_logs']
+    tags = get_path_tags(model)
 ) }}
 
 WITH base_data AS (

--- a/models/decoder_package/decoded_logs/silver/tests/test_silver__decoded_logs_full.sql
+++ b/models/decoder_package/decoded_logs/silver/tests/test_silver__decoded_logs_full.sql
@@ -3,7 +3,7 @@
 
 {{ config (
     materialized = "view",
-    tags = ['full_test']
+    tags = get_path_tags(model)
 ) }}
 
 SELECT

--- a/models/decoder_package/decoded_logs/silver/tests/test_silver__decoded_logs_recent.sql
+++ b/models/decoder_package/decoded_logs/silver/tests/test_silver__decoded_logs_recent.sql
@@ -3,7 +3,7 @@
 
 {{ config (
     materialized = "view",
-    tags = ['recent_test']
+    tags = get_path_tags(model)
 ) }}
 
 SELECT

--- a/models/decoder_package/decoded_logs/streamline/complete/streamline__decoded_logs_complete.sql
+++ b/models/decoder_package/decoded_logs/streamline/complete/streamline__decoded_logs_complete.sql
@@ -21,7 +21,7 @@
     merge_update_columns = ["_log_id"],
     post_hook = post_hook,
     full_refresh = full_refresh_type,
-    tags = ['streamline_decoded_logs_complete']
+    tags = get_path_tags(model)
 ) }}
 
 {# Main query starts here #}

--- a/models/decoder_package/decoded_logs/streamline/realtime/streamline__decoded_logs_realtime.sql
+++ b/models/decoder_package/decoded_logs/streamline/realtime/streamline__decoded_logs_realtime.sql
@@ -28,7 +28,7 @@
         } 
     ), 
     fsc_utils.if_data_call_wait()],
-    tags = ['streamline_decoded_logs_realtime']
+    tags = get_path_tags(model)
 ) }}
 
 WITH target_blocks AS (

--- a/models/decoder_package/decoded_traces/bronze/bronze__decoded_traces.sql
+++ b/models/decoder_package/decoded_traces/bronze/bronze__decoded_traces.sql
@@ -13,7 +13,7 @@
 {# Set up dbt configuration #}
 {{ config (
     materialized = 'view',
-    tags = ['bronze_decoded_traces']
+    tags = get_path_tags(model)
 ) }}
 
 {# Main query starts here #}

--- a/models/decoder_package/decoded_traces/bronze/bronze__decoded_traces_fr.sql
+++ b/models/decoder_package/decoded_traces/bronze/bronze__decoded_traces_fr.sql
@@ -3,7 +3,7 @@
 
 {{ config (
     materialized = 'view',
-    tags = ['bronze_decoded_traces']
+    tags = get_path_tags(model)
 ) }}
 
 SELECT

--- a/models/decoder_package/decoded_traces/bronze/bronze__decoded_traces_fr_v1.sql
+++ b/models/decoder_package/decoded_traces/bronze/bronze__decoded_traces_fr_v1.sql
@@ -13,7 +13,7 @@
 {# Set up dbt configuration #}
 {{ config (
     materialized = 'view',
-    tags = ['bronze_decoded_traces_streamline_v1']
+    tags = get_path_tags(model)
 ) }}
 
 {# Main query starts here #}

--- a/models/decoder_package/decoded_traces/bronze/bronze__decoded_traces_fr_v2.sql
+++ b/models/decoder_package/decoded_traces/bronze/bronze__decoded_traces_fr_v2.sql
@@ -13,7 +13,7 @@
 {# Set up dbt configuration #}
 {{ config (
     materialized = 'view',
-    tags = ['bronze_decoded_traces']
+    tags = get_path_tags(model)
 ) }}
 
 {# Main query starts here #}

--- a/models/decoder_package/decoded_traces/streamline/complete/streamline__decoded_traces_complete.sql
+++ b/models/decoder_package/decoded_traces/streamline/complete/streamline__decoded_traces_complete.sql
@@ -21,7 +21,7 @@
     merge_update_columns = ["_call_id"],
     post_hook = post_hook,
     full_refresh = full_refresh_type,
-    tags = ['streamline_decoded_traces_complete']
+    tags = get_path_tags(model)
 ) }}
 
 {# Main query starts here #}

--- a/models/decoder_package/decoded_traces/streamline/realtime/streamline__decoded_traces_realtime.sql
+++ b/models/decoder_package/decoded_traces/streamline/realtime/streamline__decoded_traces_realtime.sql
@@ -32,7 +32,7 @@
         }
     ),
     fsc_utils.if_data_call_wait()],
-    tags = ['streamline_decoded_traces_realtime']
+    tags = get_path_tags(model)
 ) }}
 
 {# Main query starts here #}

--- a/models/main_package/core/bronze/streamline/bronze__blocks.sql
+++ b/models/main_package/core/bronze/streamline/bronze__blocks.sql
@@ -19,7 +19,7 @@
 {# Set up dbt configuration #}
 {{ config (
     materialized = 'view',
-    tags = ['bronze_core']
+    tags = get_path_tags(model)
 ) }}
 
 {# Main query starts here #}

--- a/models/main_package/core/bronze/streamline/bronze__blocks_fr.sql
+++ b/models/main_package/core/bronze/streamline/bronze__blocks_fr.sql
@@ -3,7 +3,7 @@
 
 {{ config (
     materialized = 'view',
-    tags = ['bronze_core']
+    tags = get_path_tags(model)
 ) }}
 
 SELECT

--- a/models/main_package/core/bronze/streamline/bronze__blocks_fr_v1.sql
+++ b/models/main_package/core/bronze/streamline/bronze__blocks_fr_v1.sql
@@ -19,7 +19,7 @@
 {# Set up dbt configuration #}
 {{ config (
     materialized = 'view',
-    tags = ['bronze_core_streamline_v1']
+    tags = get_path_tags(model)
 ) }}
 
 {# Main query starts here #}

--- a/models/main_package/core/bronze/streamline/bronze__blocks_fr_v2.sql
+++ b/models/main_package/core/bronze/streamline/bronze__blocks_fr_v2.sql
@@ -19,7 +19,7 @@
 {# Set up dbt configuration #}
 {{ config (
     materialized = 'view',
-    tags = ['bronze_core']
+    tags = get_path_tags(model)
 ) }}
 
 {# Main query starts here #}

--- a/models/main_package/core/bronze/streamline/bronze__blocks_fr_v2_1.sql
+++ b/models/main_package/core/bronze/streamline/bronze__blocks_fr_v2_1.sql
@@ -19,7 +19,7 @@
 {# Set up dbt configuration #}
 {{ config (
     materialized = 'view',
-    tags = ['bronze_blocks_transactions_path']
+    tags = get_path_tags(model)
 ) }}
 
 {# Main query starts here #}

--- a/models/main_package/core/bronze/streamline/bronze__confirm_blocks.sql
+++ b/models/main_package/core/bronze/streamline/bronze__confirm_blocks.sql
@@ -19,7 +19,7 @@
 {# Set up dbt configuration #}
 {{ config (
     materialized = 'view',
-    tags = ['bronze_core']
+    tags = get_path_tags(model)
 ) }}
 
 {# Main query starts here #}

--- a/models/main_package/core/bronze/streamline/bronze__confirm_blocks_fr.sql
+++ b/models/main_package/core/bronze/streamline/bronze__confirm_blocks_fr.sql
@@ -3,7 +3,7 @@
 
 {{ config (
     materialized = 'view',
-    tags = ['bronze_core']
+    tags = get_path_tags(model)
 ) }}
 
 SELECT

--- a/models/main_package/core/bronze/streamline/bronze__confirm_blocks_fr_v1.sql
+++ b/models/main_package/core/bronze/streamline/bronze__confirm_blocks_fr_v1.sql
@@ -19,7 +19,7 @@
 {# Set up dbt configuration #}
 {{ config (
     materialized = 'view',
-    tags = ['bronze_core_streamline_v1']
+    tags = get_path_tags(model)
 ) }}
 
 {# Main query starts here #}

--- a/models/main_package/core/bronze/streamline/bronze__confirm_blocks_fr_v2.sql
+++ b/models/main_package/core/bronze/streamline/bronze__confirm_blocks_fr_v2.sql
@@ -19,7 +19,7 @@
 {# Set up dbt configuration #}
 {{ config (
     materialized = 'view',
-    tags = ['bronze_core']
+    tags = get_path_tags(model)
 ) }}
 
 {# Main query starts here #}

--- a/models/main_package/core/bronze/streamline/bronze__receipts.sql
+++ b/models/main_package/core/bronze/streamline/bronze__receipts.sql
@@ -19,7 +19,7 @@
 {# Set up dbt configuration #}
 {{ config (
     materialized = 'view',
-    tags = ['bronze_receipts']
+    tags = get_path_tags(model)
 ) }}
 
 {# Main query starts here #}

--- a/models/main_package/core/bronze/streamline/bronze__receipts_by_hash.sql
+++ b/models/main_package/core/bronze/streamline/bronze__receipts_by_hash.sql
@@ -19,7 +19,7 @@
 {# Set up dbt configuration #}
 {{ config (
     materialized = 'view',
-    tags = ['bronze_receipts_by_hash']
+    tags = get_path_tags(model)
 ) }}
 
 {# Main query starts here #}

--- a/models/main_package/core/bronze/streamline/bronze__receipts_by_hash_fr.sql
+++ b/models/main_package/core/bronze/streamline/bronze__receipts_by_hash_fr.sql
@@ -19,7 +19,7 @@
 {# Set up dbt configuration #}
 {{ config (
     materialized = 'view',
-    tags = ['bronze_receipts_by_hash']
+    tags = get_path_tags(model)
 ) }}
 
 {# Main query starts here #}

--- a/models/main_package/core/bronze/streamline/bronze__receipts_fr.sql
+++ b/models/main_package/core/bronze/streamline/bronze__receipts_fr.sql
@@ -3,7 +3,7 @@
 
 {{ config (
     materialized = 'view',
-    tags = ['bronze_receipts']
+    tags = get_path_tags(model)
 ) }}
 
 SELECT

--- a/models/main_package/core/bronze/streamline/bronze__receipts_fr_v1.sql
+++ b/models/main_package/core/bronze/streamline/bronze__receipts_fr_v1.sql
@@ -19,7 +19,7 @@
 {# Set up dbt configuration #}
 {{ config (
     materialized = 'view',
-    tags = ['bronze_core_streamline_v1','bronze_receipts']
+    tags = get_path_tags(model)
 ) }} 
 
 {# Main query starts here #}

--- a/models/main_package/core/bronze/streamline/bronze__receipts_fr_v2.sql
+++ b/models/main_package/core/bronze/streamline/bronze__receipts_fr_v2.sql
@@ -19,7 +19,7 @@
 {# Set up dbt configuration #}
 {{ config (
     materialized = 'view',
-    tags = ['bronze_receipts']
+    tags = get_path_tags(model)
 ) }}
 
 {# Main query starts here #}

--- a/models/main_package/core/bronze/streamline/bronze__traces.sql
+++ b/models/main_package/core/bronze/streamline/bronze__traces.sql
@@ -19,7 +19,7 @@
 {# Set up dbt configuration #}
 {{ config (
     materialized = 'view',
-    tags = ['bronze_core']
+    tags = get_path_tags(model)
 ) }}
 
 {# Main query starts here #}

--- a/models/main_package/core/bronze/streamline/bronze__traces_fr.sql
+++ b/models/main_package/core/bronze/streamline/bronze__traces_fr.sql
@@ -3,7 +3,7 @@
 
 {{ config (
     materialized = 'view',
-    tags = ['bronze_core']
+    tags = get_path_tags(model)
 ) }}
 
 SELECT

--- a/models/main_package/core/bronze/streamline/bronze__traces_fr_v1.sql
+++ b/models/main_package/core/bronze/streamline/bronze__traces_fr_v1.sql
@@ -19,7 +19,7 @@
 {# Set up dbt configuration #}
 {{ config (
     materialized = 'view',
-    tags = ['bronze_core_streamline_v1']
+    tags = get_path_tags(model)
 ) }}
 
 {# Main query starts here #}

--- a/models/main_package/core/bronze/streamline/bronze__traces_fr_v2.sql
+++ b/models/main_package/core/bronze/streamline/bronze__traces_fr_v2.sql
@@ -19,7 +19,7 @@
 {# Set up dbt configuration #}
 {{ config (
     materialized = 'view',
-    tags = ['bronze_core']
+    tags = get_path_tags(model)
 ) }}
 
 {# Main query starts here #}

--- a/models/main_package/core/bronze/streamline/bronze__transactions.sql
+++ b/models/main_package/core/bronze/streamline/bronze__transactions.sql
@@ -19,7 +19,7 @@
 {# Set up dbt configuration #}
 {{ config (
     materialized = 'view',
-    tags = ['bronze_core']
+    tags = get_path_tags(model)
 ) }}
 
 {# Main query starts here #}

--- a/models/main_package/core/bronze/streamline/bronze__transactions_fr.sql
+++ b/models/main_package/core/bronze/streamline/bronze__transactions_fr.sql
@@ -3,7 +3,7 @@
 
 {{ config (
     materialized = 'view',
-    tags = ['bronze_core']
+    tags = get_path_tags(model)
 ) }}
 
 SELECT

--- a/models/main_package/core/bronze/streamline/bronze__transactions_fr_v1.sql
+++ b/models/main_package/core/bronze/streamline/bronze__transactions_fr_v1.sql
@@ -19,7 +19,7 @@
 {# Set up dbt configuration #}
 {{ config (
     materialized = 'view',
-    tags = ['bronze_core_streamline_v1']
+    tags = get_path_tags(model)
 ) }}
 
 {# Main query starts here #}

--- a/models/main_package/core/bronze/streamline/bronze__transactions_fr_v2.sql
+++ b/models/main_package/core/bronze/streamline/bronze__transactions_fr_v2.sql
@@ -19,7 +19,7 @@
 {# Set up dbt configuration #}
 {{ config (
     materialized = 'view',
-    tags = ['bronze_core']
+    tags = get_path_tags(model)
 ) }}
 
 {# Main query starts here #}

--- a/models/main_package/core/bronze/streamline/bronze__transactions_fr_v2_1.sql
+++ b/models/main_package/core/bronze/streamline/bronze__transactions_fr_v2_1.sql
@@ -19,7 +19,7 @@
 {# Set up dbt configuration #}
 {{ config (
     materialized = 'view',
-    tags = ['bronze_blocks_transactions_path']
+    tags = get_path_tags(model)
 ) }}
 
 {# Main query starts here #}

--- a/models/main_package/core/bronze/token_reads/bronze_api__token_reads.sql
+++ b/models/main_package/core/bronze/token_reads/bronze_api__token_reads.sql
@@ -8,7 +8,7 @@
     materialized = 'incremental',
     unique_key = "contract_address",
     full_refresh = false,
-    tags = ['bronze_core', 'recent_test']
+    tags = get_path_tags(model)
 ) }}
 
 WITH base AS (

--- a/models/main_package/core/gold/core__dim_contracts.sql
+++ b/models/main_package/core/gold/core__dim_contracts.sql
@@ -6,7 +6,7 @@
     unique_key = 'address',
     merge_exclude_columns = ["inserted_timestamp"],
     post_hook = "ALTER TABLE {{ this }} ADD SEARCH OPTIMIZATION ON EQUALITY(address, symbol, name), SUBSTRING(address, symbol, name)",
-    tags = ['gold_core']
+    tags = get_path_tags(model)
 ) }}
 
 SELECT

--- a/models/main_package/core/gold/core__ez_native_transfers.sql
+++ b/models/main_package/core/gold/core__ez_native_transfers.sql
@@ -18,7 +18,7 @@
     incremental_predicates = [fsc_evm.standard_predicate()],
     full_refresh = gold_full_refresh,
     post_hook = post_hook,
-    tags = ['gold_core', 'ez_prices_model']
+    tags = get_path_tags(model)
 ) }}
 
 {% else %}
@@ -30,7 +30,7 @@
     cluster_by = ['block_timestamp::DATE'],
     incremental_predicates = [fsc_evm.standard_predicate()],
     post_hook = post_hook,
-    tags = ['gold_core', 'ez_prices_model']
+    tags = get_path_tags(model)
 ) }}
 
 {% endif %}

--- a/models/main_package/core/gold/core__ez_token_transfers.sql
+++ b/models/main_package/core/gold/core__ez_token_transfers.sql
@@ -2,7 +2,7 @@
 {% set gold_full_refresh = get_var('GLOBAL_GOLD_FR_ENABLED', false) %}
 {% set unique_key = "tx_hash" if uses_receipts_by_hash else "block_number" %}
 {% set post_hook = 'ALTER TABLE {{ this }} ADD SEARCH OPTIMIZATION ON EQUALITY(origin_from_address, origin_to_address, from_address, to_address, origin_function_signature), SUBSTRING(origin_from_address, origin_to_address, from_address, to_address, origin_function_signature)' %}
-{% set model_tags = ['ez_prices_model', 'phase_2'] %}  {# Define model-specific tags #}
+{% set model_tags = get_path_tags(model) %}  {# Define model-specific tags #}
 
 {# Log configuration details #}
 {{ log_model_details() }}

--- a/models/main_package/core/gold/core__ez_token_transfers.sql
+++ b/models/main_package/core/gold/core__ez_token_transfers.sql
@@ -2,7 +2,6 @@
 {% set gold_full_refresh = get_var('GLOBAL_GOLD_FR_ENABLED', false) %}
 {% set unique_key = "tx_hash" if uses_receipts_by_hash else "block_number" %}
 {% set post_hook = 'ALTER TABLE {{ this }} ADD SEARCH OPTIMIZATION ON EQUALITY(origin_from_address, origin_to_address, from_address, to_address, origin_function_signature), SUBSTRING(origin_from_address, origin_to_address, from_address, to_address, origin_function_signature)' %}
-{% set model_tags = get_path_tags(model) %}  {# Define model-specific tags #}
 
 {# Log configuration details #}
 {{ log_model_details() }}
@@ -17,7 +16,7 @@
     incremental_predicates = [fsc_evm.standard_predicate()],
     full_refresh = gold_full_refresh,
     post_hook = post_hook,
-    tags = get_path_tags(model, model_tags)
+    tags = get_path_tags(model)
 ) }}
 
 {% else %}

--- a/models/main_package/core/gold/core__ez_token_transfers.sql
+++ b/models/main_package/core/gold/core__ez_token_transfers.sql
@@ -17,7 +17,7 @@
     incremental_predicates = [fsc_evm.standard_predicate()],
     full_refresh = gold_full_refresh,
     post_hook = post_hook,
-    tags = get_path_tags(this.path, model_tags)
+    tags = get_path_tags(model, model_tags)
 ) }}
 
 {% else %}
@@ -29,7 +29,7 @@
     cluster_by = ['block_timestamp::DATE'],
     incremental_predicates = [fsc_evm.standard_predicate()],
     post_hook = post_hook,
-    tags = get_path_tags(this.path, model_tags)
+    tags = get_path_tags(model, model_tags)
 ) }}
 
 {% endif %}

--- a/models/main_package/core/gold/core__ez_token_transfers.sql
+++ b/models/main_package/core/gold/core__ez_token_transfers.sql
@@ -2,6 +2,7 @@
 {% set gold_full_refresh = get_var('GLOBAL_GOLD_FR_ENABLED', false) %}
 {% set unique_key = "tx_hash" if uses_receipts_by_hash else "block_number" %}
 {% set post_hook = 'ALTER TABLE {{ this }} ADD SEARCH OPTIMIZATION ON EQUALITY(origin_from_address, origin_to_address, from_address, to_address, origin_function_signature), SUBSTRING(origin_from_address, origin_to_address, from_address, to_address, origin_function_signature)' %}
+{% set model_tags = ['ez_prices_model', 'phase_2'] %}  {# Define model-specific tags #}
 
 {# Log configuration details #}
 {{ log_model_details() }}
@@ -16,7 +17,7 @@
     incremental_predicates = [fsc_evm.standard_predicate()],
     full_refresh = gold_full_refresh,
     post_hook = post_hook,
-    tags = ['gold_core', 'ez_prices_model']
+    tags = get_path_tags(this.path, model_tags)
 ) }}
 
 {% else %}
@@ -28,7 +29,7 @@
     cluster_by = ['block_timestamp::DATE'],
     incremental_predicates = [fsc_evm.standard_predicate()],
     post_hook = post_hook,
-    tags = ['gold_core', 'ez_prices_model']
+    tags = get_path_tags(this.path, model_tags)
 ) }}
 
 {% endif %}

--- a/models/main_package/core/gold/core__fact_blocks.sql
+++ b/models/main_package/core/gold/core__fact_blocks.sql
@@ -35,7 +35,7 @@
     cluster_by = ['block_timestamp::DATE'],
     incremental_predicates = [fsc_evm.standard_predicate()],
     full_refresh = gold_full_refresh,
-    tags = ['gold_core']
+    tags = get_path_tags(model)
 ) }}
 
 {% else %}
@@ -46,7 +46,7 @@
     unique_key = "block_number",
     cluster_by = ['block_timestamp::DATE'],
     incremental_predicates = [fsc_evm.standard_predicate()],
-    tags = ['gold_core']
+    tags = get_path_tags(model)
 ) }}
 
 {% endif %}

--- a/models/main_package/core/gold/core__fact_event_logs.sql
+++ b/models/main_package/core/gold/core__fact_event_logs.sql
@@ -14,7 +14,7 @@
     cluster_by = ['block_timestamp::DATE'],
     incremental_predicates = [fsc_evm.standard_predicate()],
     full_refresh = gold_full_refresh,
-    tags = ['gold_core']
+    tags = get_path_tags(model)
 ) }}
 
 {% else %}
@@ -25,7 +25,7 @@
     unique_key = unique_key,
     cluster_by = ['block_timestamp::DATE'],
     incremental_predicates = [fsc_evm.standard_predicate()],
-    tags = ['gold_core']
+    tags = get_path_tags(model)
 ) }}
 
 {% endif %}

--- a/models/main_package/core/gold/core__fact_traces.sql
+++ b/models/main_package/core/gold/core__fact_traces.sql
@@ -32,7 +32,7 @@
     cluster_by = ['block_timestamp::DATE'],
     incremental_predicates = [fsc_evm.standard_predicate()],
     full_refresh = gold_full_refresh,
-    tags = ['gold_core']
+    tags = get_path_tags(model)
 ) }}
 
 {% else %}
@@ -43,7 +43,7 @@
     unique_key = unique_key,
     cluster_by = ['block_timestamp::DATE'],
     incremental_predicates = [fsc_evm.standard_predicate()],
-    tags = ['gold_core']
+    tags = get_path_tags(model)
 ) }}    
 
 {% endif %}

--- a/models/main_package/core/gold/core__fact_transactions.sql
+++ b/models/main_package/core/gold/core__fact_transactions.sql
@@ -41,7 +41,7 @@
     cluster_by = ['block_timestamp::DATE'],
     incremental_predicates = [fsc_evm.standard_predicate()],
     full_refresh = gold_full_refresh,
-    tags = ['gold_core']
+    tags = get_path_tags(model)
 ) }}
 
 {% else %}
@@ -52,7 +52,7 @@
     unique_key = unique_key,
     cluster_by = ['block_timestamp::DATE'],
     incremental_predicates = [fsc_evm.standard_predicate()],
-    tags = ['gold_core']
+    tags = get_path_tags(model)
 ) }}
 
 {% endif %}

--- a/models/main_package/core/gold/tests/blocks/test_gold__fact_blocks_full.sql
+++ b/models/main_package/core/gold/tests/blocks/test_gold__fact_blocks_full.sql
@@ -3,7 +3,7 @@
 
 {{ config (
     materialized = "view",
-    tags = ['full_test']
+    tags = get_path_tags(model)
 ) }}
 
 SELECT

--- a/models/main_package/core/gold/tests/blocks/test_gold__fact_blocks_recent.sql
+++ b/models/main_package/core/gold/tests/blocks/test_gold__fact_blocks_recent.sql
@@ -3,7 +3,7 @@
 
 {{ config (
     materialized = "view",
-    tags = ['recent_test']
+    tags = get_path_tags(model)
 ) }}
 
 SELECT

--- a/models/main_package/core/gold/tests/event_logs/test_gold__fact_event_logs_full.sql
+++ b/models/main_package/core/gold/tests/event_logs/test_gold__fact_event_logs_full.sql
@@ -3,7 +3,7 @@
 
 {{ config (
     materialized = "view",
-    tags = ['full_test']
+    tags = get_path_tags(model)
 ) }}
 
 SELECT

--- a/models/main_package/core/gold/tests/event_logs/test_gold__fact_event_logs_recent.sql
+++ b/models/main_package/core/gold/tests/event_logs/test_gold__fact_event_logs_recent.sql
@@ -3,7 +3,7 @@
 
 {{ config (
     materialized = "view",
-    tags = ['recent_test']
+    tags = get_path_tags(model)
 ) }}
 
 SELECT

--- a/models/main_package/core/gold/tests/ez_native_transfers/test_gold__ez_native_transfers_full.sql
+++ b/models/main_package/core/gold/tests/ez_native_transfers/test_gold__ez_native_transfers_full.sql
@@ -3,7 +3,7 @@
 
 {{ config (
     materialized = "view",
-    tags = ['full_test', 'ez_prices_model']
+    tags = get_path_tags(model)
 ) }}
 
 SELECT

--- a/models/main_package/core/gold/tests/ez_native_transfers/test_gold__ez_native_transfers_recent.sql
+++ b/models/main_package/core/gold/tests/ez_native_transfers/test_gold__ez_native_transfers_recent.sql
@@ -3,7 +3,7 @@
 
 {{ config (
     materialized = "view",
-    tags = ['recent_test', 'ez_prices_model']
+    tags = get_path_tags(model)
 ) }}
 
 SELECT

--- a/models/main_package/core/gold/tests/ez_token_transfers/test_gold__ez_token_transfers_full.sql
+++ b/models/main_package/core/gold/tests/ez_token_transfers/test_gold__ez_token_transfers_full.sql
@@ -3,7 +3,7 @@
 
 {{ config (
     materialized = "view",
-    tags = ['full_test', 'ez_prices_model']
+    tags = get_path_tags(model)
 ) }}
 
 SELECT

--- a/models/main_package/core/gold/tests/ez_token_transfers/test_gold__ez_token_transfers_recent.sql
+++ b/models/main_package/core/gold/tests/ez_token_transfers/test_gold__ez_token_transfers_recent.sql
@@ -3,7 +3,7 @@
 
 {{ config (
     materialized = "view",
-    tags = ['recent_test', 'ez_prices_model']
+    tags = get_path_tags(model)
 ) }}
 
 SELECT

--- a/models/main_package/core/gold/tests/traces/test_gold__fact_traces_full.sql
+++ b/models/main_package/core/gold/tests/traces/test_gold__fact_traces_full.sql
@@ -3,7 +3,7 @@
 
 {{ config (
     materialized = "view",
-    tags = ['full_test']
+    tags = get_path_tags(model)
 ) }}
 
 SELECT

--- a/models/main_package/core/gold/tests/traces/test_gold__fact_traces_recent.sql
+++ b/models/main_package/core/gold/tests/traces/test_gold__fact_traces_recent.sql
@@ -3,7 +3,7 @@
 
 {{ config (
     materialized = "view",
-    tags = ['recent_test']
+    tags = get_path_tags(model)
 ) }}
 
 SELECT

--- a/models/main_package/core/gold/tests/transactions/test_gold__fact_transactions_full.sql
+++ b/models/main_package/core/gold/tests/transactions/test_gold__fact_transactions_full.sql
@@ -3,7 +3,7 @@
 
 {{ config (
     materialized = "view",
-    tags = ['full_test']
+    tags = get_path_tags(model)
 ) }}
 
 SELECT

--- a/models/main_package/core/gold/tests/transactions/test_gold__fact_transactions_recent.sql
+++ b/models/main_package/core/gold/tests/transactions/test_gold__fact_transactions_recent.sql
@@ -3,7 +3,7 @@
 
 {{ config (
     materialized = "view",
-    tags = ['recent_test']
+    tags = get_path_tags(model)
 ) }}
 
 SELECT

--- a/models/main_package/core/nft/nft__ez_nft_transfers.sql
+++ b/models/main_package/core/nft/nft__ez_nft_transfers.sql
@@ -15,7 +15,7 @@
         incremental_predicates = [fsc_evm.standard_predicate()],
         full_refresh = nft_full_refresh,
         post_hook = post_hook,
-        tags = ['nft_core']
+        tags = get_path_tags(model)
     ) }}
 {% else %}
     {{ config (
@@ -25,7 +25,7 @@
         cluster_by = ['block_timestamp::DATE'],
         incremental_predicates = [fsc_evm.standard_predicate()],
         post_hook = post_hook,
-        tags = ['nft_core']
+        tags = get_path_tags(model)
     ) }}
 {% endif %}
 

--- a/models/main_package/core/nft/tests/test_nft__ez_nft_transfers_full.sql
+++ b/models/main_package/core/nft/tests/test_nft__ez_nft_transfers_full.sql
@@ -3,7 +3,7 @@
 
 {{ config (
     materialized = "view",
-    tags = ['full_test']
+    tags = get_path_tags(model)
 ) }}
 
 SELECT

--- a/models/main_package/core/nft/tests/test_nft__ez_nft_transfers_recent.sql
+++ b/models/main_package/core/nft/tests/test_nft__ez_nft_transfers_recent.sql
@@ -3,7 +3,7 @@
 
 {{ config (
     materialized = "view",
-    tags = ['recent_test']
+    tags = get_path_tags(model)
 ) }}
 
 SELECT

--- a/models/main_package/core/silver/silver__blocks.sql
+++ b/models/main_package/core/silver/silver__blocks.sql
@@ -14,7 +14,7 @@
     post_hook = "ALTER TABLE {{ this }} ADD SEARCH OPTIMIZATION on equality(block_number)",
     incremental_predicates = [fsc_evm.standard_predicate()],
     full_refresh = silver_full_refresh,
-    tags = ['silver_core']
+    tags = get_path_tags(model)
 ) }}
 
 {% else %}
@@ -26,7 +26,7 @@
     cluster_by = ['modified_timestamp::DATE','partition_key'],
     post_hook = "ALTER TABLE {{ this }} ADD SEARCH OPTIMIZATION on equality(block_number)",
     incremental_predicates = [fsc_evm.standard_predicate()],
-    tags = ['silver_core']
+    tags = get_path_tags(model)
 ) }}
 
 {% endif %}

--- a/models/main_package/core/silver/silver__confirm_blocks.sql
+++ b/models/main_package/core/silver/silver__confirm_blocks.sql
@@ -16,7 +16,7 @@
     post_hook = "ALTER TABLE {{ this }} ADD SEARCH OPTIMIZATION on equality(block_number)",
     incremental_predicates = [fsc_evm.standard_predicate()],
     full_refresh = silver_full_refresh,
-    tags = ['silver_confirm_blocks']
+    tags = get_path_tags(model)
 ) }}
 
 {% else %}
@@ -28,7 +28,7 @@
     cluster_by = ['modified_timestamp::DATE','partition_key'],
     post_hook = "ALTER TABLE {{ this }} ADD SEARCH OPTIMIZATION on equality(block_number)",
     incremental_predicates = [fsc_evm.standard_predicate()],
-    tags = ['silver_confirm_blocks']
+    tags = get_path_tags(model)
 ) }}
 
 {% endif %}

--- a/models/main_package/core/silver/silver__contracts.sql
+++ b/models/main_package/core/silver/silver__contracts.sql
@@ -5,7 +5,7 @@
     materialized = 'incremental',
     unique_key = 'contract_address',
     merge_exclude_columns = ["inserted_timestamp"],
-    tags = ['silver_core']
+    tags = get_path_tags(model)
 ) }}
 
 WITH base_metadata AS (

--- a/models/main_package/core/silver/silver__created_contracts.sql
+++ b/models/main_package/core/silver/silver__created_contracts.sql
@@ -6,7 +6,7 @@
     unique_key = "created_contract_address",
     merge_exclude_columns = ["inserted_timestamp"],
     post_hook = "ALTER TABLE {{ this }} ADD SEARCH OPTIMIZATION ON EQUALITY(block_timestamp, tx_hash, created_contract_address, creator_address), SUBSTRING(created_contract_address, creator_address)",
-    tags = ['silver_core']
+    tags = get_path_tags(model)
 ) }}
 
 SELECT

--- a/models/main_package/core/silver/silver__proxies.sql
+++ b/models/main_package/core/silver/silver__proxies.sql
@@ -6,7 +6,7 @@
     unique_key = ["contract_address", "implementation_contract"],
     cluster_by = ["start_timestamp::date"],
     post_hook = "ALTER TABLE {{ this }} ADD SEARCH OPTIMIZATION",
-    tags = ['silver_core']
+    tags = get_path_tags(model)
 ) }}
 
 WITH base AS (

--- a/models/main_package/core/silver/silver__receipts.sql
+++ b/models/main_package/core/silver/silver__receipts.sql
@@ -18,7 +18,7 @@
     post_hook = post_hook,
     incremental_predicates = [fsc_evm.standard_predicate()],
     full_refresh = silver_full_refresh,
-    tags = ['silver_core']
+    tags = get_path_tags(model)
 ) }}
 
 {% else %}
@@ -30,7 +30,7 @@
     cluster_by = ['modified_timestamp::DATE','partition_key'],
     post_hook = post_hook,
     incremental_predicates = [fsc_evm.standard_predicate()],
-    tags = ['silver_core']
+    tags = get_path_tags(model)
 ) }}
 
 {% endif %}

--- a/models/main_package/core/silver/silver__relevant_contracts.sql
+++ b/models/main_package/core/silver/silver__relevant_contracts.sql
@@ -5,7 +5,7 @@
     materialized = 'incremental',
     unique_key = "contract_address",
     post_hook = "ALTER TABLE {{ this }} ADD SEARCH OPTIMIZATION on equality(contract_address)",
-    tags = ['silver_core']
+    tags = get_path_tags(model)
 ) }}
 
 WITH emitted_events AS (

--- a/models/main_package/core/silver/silver__traces.sql
+++ b/models/main_package/core/silver/silver__traces.sql
@@ -23,7 +23,7 @@
     post_hook = "ALTER TABLE {{ this }} ADD SEARCH OPTIMIZATION on equality(block_number)",
     incremental_predicates = [fsc_evm.standard_predicate()],
     full_refresh = silver_full_refresh,
-    tags = ['silver_core']
+    tags = get_path_tags(model)
 ) }}
 
 {% else %}
@@ -35,7 +35,7 @@
     cluster_by = ['modified_timestamp::DATE','partition_key'],
     post_hook = "ALTER TABLE {{ this }} ADD SEARCH OPTIMIZATION on equality(block_number)",
     incremental_predicates = [fsc_evm.standard_predicate()],
-    tags = ['silver_core']
+    tags = get_path_tags(model)
 ) }}
 
 {% endif %}

--- a/models/main_package/core/silver/silver__transactions.sql
+++ b/models/main_package/core/silver/silver__transactions.sql
@@ -15,7 +15,7 @@
     post_hook = "ALTER TABLE {{ this }} ADD SEARCH OPTIMIZATION on equality(block_number)",
     incremental_predicates = [fsc_evm.standard_predicate()],
     full_refresh = silver_full_refresh,
-    tags = ['silver_core']
+    tags = get_path_tags(model)
 ) }}
 
 {% else %}
@@ -27,7 +27,7 @@
     cluster_by = ['modified_timestamp::DATE','partition_key'],
     post_hook = "ALTER TABLE {{ this }} ADD SEARCH OPTIMIZATION on equality(block_number)",
     incremental_predicates = [fsc_evm.standard_predicate()],
-    tags = ['silver_core']
+    tags = get_path_tags(model)
 ) }}
 
 {% endif %}

--- a/models/main_package/core/silver/tests/blocks/test_silver__blocks_full.sql
+++ b/models/main_package/core/silver/tests/blocks/test_silver__blocks_full.sql
@@ -3,7 +3,7 @@
 
 {{ config (
     materialized = "view",
-    tags = ['full_test']
+    tags = get_path_tags(model)
 ) }}
 
 SELECT

--- a/models/main_package/core/silver/tests/blocks/test_silver__blocks_recent.sql
+++ b/models/main_package/core/silver/tests/blocks/test_silver__blocks_recent.sql
@@ -3,7 +3,7 @@
 
 {{ config (
     materialized = "view",
-    tags = ['recent_test']
+    tags = get_path_tags(model)
 ) }}
 
 SELECT

--- a/models/main_package/core/silver/tests/confirm_blocks/test_silver__confirm_blocks_full.sql
+++ b/models/main_package/core/silver/tests/confirm_blocks/test_silver__confirm_blocks_full.sql
@@ -3,7 +3,7 @@
 
 {{ config (
     materialized = "view",
-    tags = ['full_test']
+    tags = get_path_tags(model)
 ) }}
 
 SELECT

--- a/models/main_package/core/silver/tests/confirm_blocks/test_silver__confirm_blocks_recent.sql
+++ b/models/main_package/core/silver/tests/confirm_blocks/test_silver__confirm_blocks_recent.sql
@@ -3,7 +3,7 @@
 
 {{ config (
     materialized = "view",
-    tags = ['recent_test_confirm_blocks']
+    tags = get_path_tags(model)
 ) }}
 
 {%- set default_hours = -24 * 5 -%}

--- a/models/main_package/core/silver/tests/contracts/test_silver__contracts_full.sql
+++ b/models/main_package/core/silver/tests/contracts/test_silver__contracts_full.sql
@@ -3,7 +3,7 @@
 
 {{ config (
     materialized = "view",
-    tags = ['full_test']
+    tags = get_path_tags(model)
 ) }}
 
 SELECT

--- a/models/main_package/core/silver/tests/contracts/test_silver__contracts_recent.sql
+++ b/models/main_package/core/silver/tests/contracts/test_silver__contracts_recent.sql
@@ -3,7 +3,7 @@
 
 {{ config (
     materialized = "view",
-    tags = ['daily_test']
+    tags = get_path_tags(model)
 ) }}
 
 SELECT

--- a/models/main_package/core/silver/tests/created_contracts/test_silver__created_contracts_full.sql
+++ b/models/main_package/core/silver/tests/created_contracts/test_silver__created_contracts_full.sql
@@ -3,7 +3,7 @@
 
 {{ config (
     materialized = "view",
-    tags = ['full_test']
+    tags = get_path_tags(model)
 ) }}
 
 SELECT

--- a/models/main_package/core/silver/tests/created_contracts/test_silver__created_contracts_recent.sql
+++ b/models/main_package/core/silver/tests/created_contracts/test_silver__created_contracts_recent.sql
@@ -3,7 +3,7 @@
 
 {{ config (
     materialized = "view",
-    tags = ['daily_test']
+    tags = get_path_tags(model)
 ) }}
 
 SELECT

--- a/models/main_package/core/silver/tests/proxies/test_silver__proxies_full.sql
+++ b/models/main_package/core/silver/tests/proxies/test_silver__proxies_full.sql
@@ -3,7 +3,7 @@
 
 {{ config (
     materialized = "view",
-    tags = ['full_test']
+    tags = get_path_tags(model)
 ) }}
 
 SELECT

--- a/models/main_package/core/silver/tests/proxies/test_silver__proxies_recent.sql
+++ b/models/main_package/core/silver/tests/proxies/test_silver__proxies_recent.sql
@@ -3,7 +3,7 @@
 
 {{ config (
     materialized = "view",
-    tags = ['daily_test']
+    tags = get_path_tags(model)
 ) }}
 
 SELECT

--- a/models/main_package/core/silver/tests/receipts/test_silver__receipts_full.sql
+++ b/models/main_package/core/silver/tests/receipts/test_silver__receipts_full.sql
@@ -3,7 +3,7 @@
 
 {{ config (
     materialized = "view",
-    tags = ['full_test']
+    tags = get_path_tags(model)
 ) }}
 
 SELECT

--- a/models/main_package/core/silver/tests/receipts/test_silver__receipts_recent.sql
+++ b/models/main_package/core/silver/tests/receipts/test_silver__receipts_recent.sql
@@ -3,7 +3,7 @@
 
 {{ config (
     materialized = "view",
-    tags = ['recent_test']
+    tags = get_path_tags(model)
 ) }}
 
 SELECT

--- a/models/main_package/core/silver/tests/traces/test_silver__traces_full.sql
+++ b/models/main_package/core/silver/tests/traces/test_silver__traces_full.sql
@@ -3,7 +3,7 @@
 
 {{ config (
     materialized = "view",
-    tags = ['full_test']
+    tags = get_path_tags(model)
 ) }}
 
 SELECT

--- a/models/main_package/core/silver/tests/traces/test_silver__traces_recent.sql
+++ b/models/main_package/core/silver/tests/traces/test_silver__traces_recent.sql
@@ -3,7 +3,7 @@
 
 {{ config (
     materialized = "view",
-    tags = ['recent_test']
+    tags = get_path_tags(model)
 ) }}
 
 SELECT

--- a/models/main_package/core/silver/tests/transactions/test_silver__transactions_full.sql
+++ b/models/main_package/core/silver/tests/transactions/test_silver__transactions_full.sql
@@ -3,7 +3,7 @@
 
 {{ config (
     materialized = "view",
-    tags = ['full_test']
+    tags = get_path_tags(model)
 ) }}
 
 SELECT

--- a/models/main_package/core/silver/tests/transactions/test_silver__transactions_recent.sql
+++ b/models/main_package/core/silver/tests/transactions/test_silver__transactions_recent.sql
@@ -3,7 +3,7 @@
 
 {{ config (
     materialized = "view",
-    tags = ['recent_test']
+    tags = get_path_tags(model)
 ) }}
 
 SELECT

--- a/models/main_package/core/streamline/complete/streamline__blocks_complete.sql
+++ b/models/main_package/core/streamline/complete/streamline__blocks_complete.sql
@@ -19,7 +19,7 @@
     cluster_by = "ROUND(block_number, -3)",
     post_hook = post_hook,
     full_refresh = full_refresh_type,
-    tags = ['streamline_core_complete']
+    tags = get_path_tags(model)
 ) }}
 
 {# Main query starts here #}

--- a/models/main_package/core/streamline/complete/streamline__confirm_blocks_complete.sql
+++ b/models/main_package/core/streamline/complete/streamline__confirm_blocks_complete.sql
@@ -19,7 +19,7 @@
     cluster_by = "ROUND(block_number, -3)",
     post_hook = post_hook,
     full_refresh = full_refresh_type,
-    tags = ['streamline_core_complete_confirm_blocks']
+    tags = get_path_tags(model)
 ) }}
 
 {# Main query starts here #}

--- a/models/main_package/core/streamline/complete/streamline__receipts_by_hash_complete.sql
+++ b/models/main_package/core/streamline/complete/streamline__receipts_by_hash_complete.sql
@@ -21,7 +21,7 @@
     cluster_by = "ROUND(block_number, -3)",
     post_hook = post_hook,
     full_refresh = full_refresh_type,
-    tags = ['streamline_core_complete_receipts_by_hash']
+    tags = get_path_tags(model)
 ) }}
 
 {# Main query starts here #}

--- a/models/main_package/core/streamline/complete/streamline__receipts_complete.sql
+++ b/models/main_package/core/streamline/complete/streamline__receipts_complete.sql
@@ -19,7 +19,7 @@
     cluster_by = "ROUND(block_number, -3)",
     post_hook = post_hook,
     full_refresh = full_refresh_type,
-    tags = ['streamline_core_complete_receipts']
+    tags = get_path_tags(model)
 ) }}
 
 {# Main query starts here #}

--- a/models/main_package/core/streamline/complete/streamline__traces_complete.sql
+++ b/models/main_package/core/streamline/complete/streamline__traces_complete.sql
@@ -19,7 +19,7 @@
     cluster_by = "ROUND(block_number, -3)",
     post_hook = post_hook,
     full_refresh = full_refresh_type,
-    tags = ['streamline_core_complete']
+    tags = get_path_tags(model)
 ) }}
 
 {# Main query starts here #}

--- a/models/main_package/core/streamline/complete/streamline__transactions_complete.sql
+++ b/models/main_package/core/streamline/complete/streamline__transactions_complete.sql
@@ -19,7 +19,7 @@
     cluster_by = "ROUND(block_number, -3)",
     post_hook = post_hook,
     full_refresh = full_refresh_type,
-    tags = ['streamline_core_complete']
+    tags = get_path_tags(model)
 ) }}
 
 {# Main query starts here #}

--- a/models/main_package/core/streamline/history/streamline__blocks_transactions_history.sql
+++ b/models/main_package/core/streamline/history/streamline__blocks_transactions_history.sql
@@ -38,7 +38,7 @@
         target = "{{this.schema}}.{{this.identifier}}",
         params = streamline_params
     ),
-    tags = ['streamline_core_history']
+    tags = get_path_tags(model)
 ) }}
 
 {# Main query starts here #}

--- a/models/main_package/core/streamline/history/streamline__confirm_blocks_history.sql
+++ b/models/main_package/core/streamline/history/streamline__confirm_blocks_history.sql
@@ -37,7 +37,7 @@
         target = "{{this.schema}}.{{this.identifier}}",
         params = streamline_params
     ),
-    tags = ['streamline_core_history_confirm_blocks']
+    tags = get_path_tags(model)
 ) }}
 
 {# Main query starts here #}

--- a/models/main_package/core/streamline/history/streamline__receipts_by_hash_history.sql
+++ b/models/main_package/core/streamline/history/streamline__receipts_by_hash_history.sql
@@ -41,7 +41,7 @@
         target = "{{this.schema}}.{{this.identifier}}",
         params = streamline_params
     ),
-    tags = ['streamline_core_history_receipts_by_hash']
+    tags = get_path_tags(model)
 ) }}
 
 {# Main query starts here #}

--- a/models/main_package/core/streamline/history/streamline__receipts_history.sql
+++ b/models/main_package/core/streamline/history/streamline__receipts_history.sql
@@ -37,7 +37,7 @@
         target = "{{this.schema}}.{{this.identifier}}",
         params = streamline_params
     ),
-    tags = ['streamline_core_history_receipts']
+    tags = get_path_tags(model)
 ) }}
 
 {# Main query starts here #}

--- a/models/main_package/core/streamline/history/streamline__traces_history.sql
+++ b/models/main_package/core/streamline/history/streamline__traces_history.sql
@@ -39,7 +39,7 @@
         target = "{{this.schema}}.{{this.identifier}}",
         params = streamline_params
     ),
-    tags = ['streamline_core_history']
+    tags = get_path_tags(model)
 ) }}
 
 {# Main query starts here #}

--- a/models/main_package/core/streamline/realtime/streamline__blocks_transactions_realtime.sql
+++ b/models/main_package/core/streamline/realtime/streamline__blocks_transactions_realtime.sql
@@ -37,7 +37,7 @@
         target = "{{this.schema}}.{{this.identifier}}",
         params = streamline_params
     ),
-    tags = ['streamline_core_realtime']
+    tags = get_path_tags(model)
 ) }}
 
 {# Main query starts here #}

--- a/models/main_package/core/streamline/realtime/streamline__confirm_blocks_realtime.sql
+++ b/models/main_package/core/streamline/realtime/streamline__confirm_blocks_realtime.sql
@@ -37,7 +37,7 @@
         target = "{{this.schema}}.{{this.identifier}}",
         params = streamline_params
     ),
-    tags = ['streamline_core_realtime_confirm_blocks']
+    tags = get_path_tags(model)
 ) }}
 
 {# Main query starts here #}

--- a/models/main_package/core/streamline/realtime/streamline__receipts_by_hash_realtime.sql
+++ b/models/main_package/core/streamline/realtime/streamline__receipts_by_hash_realtime.sql
@@ -42,7 +42,7 @@
         target = "{{this.schema}}.{{this.identifier}}",
         params = streamline_params
     ),
-    tags = ['streamline_core_realtime_receipts_by_hash']
+    tags = get_path_tags(model)
 ) }}
 
 {# Main query starts here #}

--- a/models/main_package/core/streamline/realtime/streamline__receipts_realtime.sql
+++ b/models/main_package/core/streamline/realtime/streamline__receipts_realtime.sql
@@ -37,7 +37,7 @@
         target = "{{this.schema}}.{{this.identifier}}",
         params = streamline_params
     ),
-    tags = ['streamline_core_realtime_receipts']
+    tags = get_path_tags(model)
 ) }}
 
 {# Main query starts here #}

--- a/models/main_package/core/streamline/realtime/streamline__traces_realtime.sql
+++ b/models/main_package/core/streamline/realtime/streamline__traces_realtime.sql
@@ -39,7 +39,7 @@
         target = "{{this.schema}}.{{this.identifier}}",
         params = streamline_params
     ),
-    tags = ['streamline_core_realtime']
+    tags = get_path_tags(model)
 ) }}
 
 {# Main query starts here #}

--- a/models/main_package/core/streamline/streamline__blocks.sql
+++ b/models/main_package/core/streamline/streamline__blocks.sql
@@ -3,7 +3,7 @@
 
 {{ config (
     materialized = "view",
-    tags = ['streamline_core_complete']
+    tags = get_path_tags(model)
 ) }}
 
 SELECT

--- a/models/main_package/core/streamline/streamline__get_chainhead.sql
+++ b/models/main_package/core/streamline/streamline__get_chainhead.sql
@@ -7,7 +7,7 @@
 
 {{ config (
     materialized = 'table',
-    tags = ['streamline_core_complete','chainhead']
+    tags = get_path_tags(model)
 ) }}
 
 SELECT

--- a/models/main_package/github_actions/github_actions__current_task_status.sql
+++ b/models/main_package/github_actions/github_actions__current_task_status.sql
@@ -3,7 +3,7 @@
 
 {{ config(
     materialized = 'view',
-    tags = ['gha_tasks']
+    tags = get_path_tags(model)
 ) }}
 
 {{ fsc_utils.gha_task_current_status_view() }}

--- a/models/main_package/github_actions/github_actions__task_history.sql
+++ b/models/main_package/github_actions/github_actions__task_history.sql
@@ -3,7 +3,7 @@
 
 {{ config(
     materialized = 'view',
-    tags = ['gha_tasks']
+    tags = get_path_tags(model)
 ) }}
 
 {{ fsc_utils.gha_task_history_view() }}

--- a/models/main_package/github_actions/github_actions__task_performance.sql
+++ b/models/main_package/github_actions/github_actions__task_performance.sql
@@ -3,7 +3,7 @@
 
 {{ config(
     materialized = 'view',
-    tags = ['gha_tasks']
+    tags = get_path_tags(model)
 ) }}
 
 {{ fsc_utils.gha_task_performance_view() }}

--- a/models/main_package/github_actions/github_actions__task_schedule.sql
+++ b/models/main_package/github_actions/github_actions__task_schedule.sql
@@ -3,7 +3,7 @@
 
 {{ config(
     materialized = 'view',
-    tags = ['gha_tasks']
+    tags = get_path_tags(model)
 ) }}
 
 {{ fsc_utils.gha_task_schedule_view() }}

--- a/models/main_package/github_actions/github_actions__tasks.sql
+++ b/models/main_package/github_actions/github_actions__tasks.sql
@@ -3,7 +3,7 @@
 
 {{ config(
     materialized = 'view',
-    tags = ['gha_tasks']
+    tags = get_path_tags(model)
 ) }}
 
 {{ fsc_utils.gha_tasks_view() }}

--- a/models/main_package/labels/bronze/bronze__labels.sql
+++ b/models/main_package/labels/bronze/bronze__labels.sql
@@ -5,7 +5,7 @@
 
 {{ config(
     materialized = 'view',
-    tags = ['bronze_labels']
+    tags = get_path_tags(model)
 ) }}
 
 SELECT

--- a/models/main_package/labels/gold/core__dim_labels.sql
+++ b/models/main_package/labels/gold/core__dim_labels.sql
@@ -10,7 +10,7 @@
     merge_exclude_columns = ["inserted_timestamp"],
     cluster_by = 'modified_timestamp::DATE',
     post_hook = post_hook,
-    tags = ['gold_labels']
+    tags = get_path_tags(model)
 ) }}
 
 SELECT

--- a/models/main_package/labels/silver/silver__labels.sql
+++ b/models/main_package/labels/silver/silver__labels.sql
@@ -7,7 +7,7 @@
     incremental_strategy = 'merge',
     merge_exclude_columns = ["inserted_timestamp"],
     cluster_by = 'modified_timestamp::DATE',
-    tags = ['silver_labels']
+    tags = get_path_tags(model)
 ) }}
 
 SELECT

--- a/models/main_package/observability/observability__blocks.sql
+++ b/models/main_package/observability/observability__blocks.sql
@@ -10,7 +10,7 @@
     materialized = 'incremental',
     unique_key = 'test_timestamp',
     full_refresh = false,
-    tags = ['observability']
+    tags = get_path_tags(model)
 ) }}
 
 WITH lookback AS (

--- a/models/main_package/observability/observability__logs.sql
+++ b/models/main_package/observability/observability__logs.sql
@@ -10,7 +10,7 @@
     materialized = 'incremental',
     unique_key = 'test_timestamp',
     full_refresh = false,
-    tags = ['observability']
+    tags = get_path_tags(model)
 ) }}
 
 WITH lookback AS (

--- a/models/main_package/observability/observability__receipts.sql
+++ b/models/main_package/observability/observability__receipts.sql
@@ -10,7 +10,7 @@
     materialized = 'incremental',
     unique_key = 'test_timestamp',
     full_refresh = false,
-    tags = ['observability']
+    tags = get_path_tags(model)
 ) }}
 
 WITH lookback AS (

--- a/models/main_package/observability/observability__traces.sql
+++ b/models/main_package/observability/observability__traces.sql
@@ -10,7 +10,7 @@
     materialized = 'incremental',
     unique_key = 'test_timestamp',
     full_refresh = false,
-    tags = ['observability']
+    tags = get_path_tags(model)
 ) }}
 
 WITH lookback AS (

--- a/models/main_package/observability/observability__transactions.sql
+++ b/models/main_package/observability/observability__transactions.sql
@@ -10,7 +10,7 @@
     materialized = 'incremental',
     unique_key = 'test_timestamp',
     full_refresh = false,
-    tags = ['observability']
+    tags = get_path_tags(model)
 ) }}
 
 WITH lookback AS (

--- a/models/main_package/prices/bronze/bronze__complete_native_asset_metadata.sql
+++ b/models/main_package/prices/bronze/bronze__complete_native_asset_metadata.sql
@@ -8,7 +8,7 @@
 {# Set up dbt configuration #}
 {{ config (
     materialized = 'view',
-    tags = ['bronze_prices']
+    tags = get_path_tags(model)
 ) }}
 
 {# Main query starts here #}

--- a/models/main_package/prices/bronze/bronze__complete_native_prices.sql
+++ b/models/main_package/prices/bronze/bronze__complete_native_prices.sql
@@ -8,7 +8,7 @@
 {# Set up dbt configuration #}
 {{ config (
     materialized = 'view',
-    tags = ['bronze_prices']
+    tags = get_path_tags(model)
 ) }}
 
 {# Main query starts here #}

--- a/models/main_package/prices/bronze/bronze__complete_provider_asset_metadata.sql
+++ b/models/main_package/prices/bronze/bronze__complete_provider_asset_metadata.sql
@@ -7,7 +7,7 @@
 {# Set up dbt configuration #}
 {{ config (
     materialized = 'view',
-    tags = ['bronze_prices']
+    tags = get_path_tags(model)
 ) }}
 
 {# Main query starts here #}

--- a/models/main_package/prices/bronze/bronze__complete_provider_prices.sql
+++ b/models/main_package/prices/bronze/bronze__complete_provider_prices.sql
@@ -4,7 +4,7 @@
 {# Set up dbt configuration #}
 {{ config (
     materialized = 'view',
-    tags = ['bronze_prices']
+    tags = get_path_tags(model)
 ) }}
 
 {# Main query starts here #}

--- a/models/main_package/prices/bronze/bronze__complete_token_asset_metadata.sql
+++ b/models/main_package/prices/bronze/bronze__complete_token_asset_metadata.sql
@@ -8,7 +8,7 @@
 {# Set up dbt configuration #}
 {{ config (
     materialized = 'view',
-    tags = ['bronze_prices']
+    tags = get_path_tags(model)
 ) }}
 
 {# Main query starts here #}

--- a/models/main_package/prices/bronze/bronze__complete_token_prices.sql
+++ b/models/main_package/prices/bronze/bronze__complete_token_prices.sql
@@ -8,7 +8,7 @@
 {# Set up dbt configuration #}
 {{ config (
     materialized = 'view',
-    tags = ['bronze_prices']
+    tags = get_path_tags(model)
 ) }}
 
 {# Main query starts here #}

--- a/models/main_package/prices/gold/price__dim_asset_metadata.sql
+++ b/models/main_package/prices/gold/price__dim_asset_metadata.sql
@@ -10,7 +10,7 @@
     incremental_strategy = 'delete+insert',
     unique_key = 'dim_asset_metadata_id',
     post_hook = post_hook,
-    tags = ['gold_prices']
+    tags = get_path_tags(model)
 ) }}
 
 {# Main query starts here #}

--- a/models/main_package/prices/gold/price__ez_asset_metadata.sql
+++ b/models/main_package/prices/gold/price__ez_asset_metadata.sql
@@ -10,7 +10,7 @@
     incremental_strategy = 'delete+insert',
     unique_key = 'ez_asset_metadata_id',
     post_hook = post_hook,
-    tags = ['gold_prices']
+    tags = get_path_tags(model)
 ) }}
 
 {# Main query starts here #}

--- a/models/main_package/prices/gold/price__ez_prices_hourly.sql
+++ b/models/main_package/prices/gold/price__ez_prices_hourly.sql
@@ -11,7 +11,7 @@
     unique_key = 'ez_prices_hourly_id',
     cluster_by = ['hour::DATE'],
     post_hook = post_hook,
-    tags = ['gold_prices']
+    tags = get_path_tags(model)
 ) }}
 
 {# Main query starts here #}

--- a/models/main_package/prices/gold/price__fact_prices_ohlc_hourly.sql
+++ b/models/main_package/prices/gold/price__fact_prices_ohlc_hourly.sql
@@ -11,7 +11,7 @@
     unique_key = 'fact_prices_ohlc_hourly_id',
     cluster_by = ['hour::DATE','provider'],
     post_hook = post_hook,
-    tags = ['gold_prices']
+    tags = get_path_tags(model)
 ) }}
 
 {# Main query starts here #}

--- a/models/main_package/prices/silver/silver__complete_native_asset_metadata.sql
+++ b/models/main_package/prices/silver/silver__complete_native_asset_metadata.sql
@@ -6,7 +6,7 @@
     materialized = 'incremental',
     incremental_strategy = 'delete+insert',
     unique_key = 'complete_native_asset_metadata_id',
-    tags = ['silver_prices']
+    tags = get_path_tags(model)
 ) }}
 
 {# Main query starts here #}

--- a/models/main_package/prices/silver/silver__complete_native_prices.sql
+++ b/models/main_package/prices/silver/silver__complete_native_prices.sql
@@ -7,7 +7,7 @@
     incremental_strategy = 'delete+insert',
     unique_key = 'complete_native_prices_id',
     cluster_by = ['hour::DATE'],
-    tags = ['silver_prices']
+    tags = get_path_tags(model)
 ) }}
 
 {# Main query starts here #}

--- a/models/main_package/prices/silver/silver__complete_provider_asset_metadata.sql
+++ b/models/main_package/prices/silver/silver__complete_provider_asset_metadata.sql
@@ -6,7 +6,7 @@
     materialized = 'incremental',
     incremental_strategy = 'delete+insert',
     unique_key = 'complete_provider_asset_metadata_id',
-    tags = ['silver_prices']
+    tags = get_path_tags(model)
 ) }}
 
 {# Main query starts here #}

--- a/models/main_package/prices/silver/silver__complete_provider_prices.sql
+++ b/models/main_package/prices/silver/silver__complete_provider_prices.sql
@@ -7,7 +7,7 @@
     incremental_strategy = 'delete+insert',
     unique_key = 'complete_provider_prices_id',
     cluster_by = ['recorded_hour::DATE','provider'],
-    tags = ['silver_prices']
+    tags = get_path_tags(model)
 ) }}
 
 {# Main query starts here #}

--- a/models/main_package/prices/silver/silver__complete_token_asset_metadata.sql
+++ b/models/main_package/prices/silver/silver__complete_token_asset_metadata.sql
@@ -6,7 +6,7 @@
     materialized = 'incremental',
     incremental_strategy = 'delete+insert',
     unique_key = 'complete_token_asset_metadata_id',
-    tags = ['silver_prices']
+    tags = get_path_tags(model)
 ) }}
 
 {# Main query starts here #}

--- a/models/main_package/prices/silver/silver__complete_token_prices.sql
+++ b/models/main_package/prices/silver/silver__complete_token_prices.sql
@@ -7,7 +7,7 @@
     incremental_strategy = 'delete+insert',
     unique_key = 'complete_token_prices_id',
     cluster_by = ['hour::DATE'],
-    tags = ['silver_prices']
+    tags = get_path_tags(model)
 ) }}
 
 {# Main query starts here #}

--- a/models/main_package/utils/utils__number_sequence.sql
+++ b/models/main_package/utils/utils__number_sequence.sql
@@ -10,7 +10,7 @@
     cluster_by = 'round(_id,-3)',
     post_hook = post_hook,
     full_refresh = false,
-    tags = ['utils']
+    tags = get_path_tags(model)
 ) }}
 
 SELECT

--- a/models/main_package/variables/silver__dim_variables.sql
+++ b/models/main_package/variables/silver__dim_variables.sql
@@ -3,7 +3,7 @@
 
 {{ config(
     materialized = 'view',
-    tags = ['silver_vars']
+    tags = get_path_tags(model)
 ) }}
 
 SELECT

--- a/models/main_package/variables/silver__ez_variables.sql
+++ b/models/main_package/variables/silver__ez_variables.sql
@@ -3,7 +3,7 @@
 
 {{ config(
     materialized = 'view',
-    tags = ['silver_vars']
+    tags = get_path_tags(model)
 ) }}
 
 SELECT

--- a/models/main_package/variables/silver__fact_variables.sql
+++ b/models/main_package/variables/silver__fact_variables.sql
@@ -5,7 +5,7 @@
 
 {{ config(
     materialized = 'view',
-    tags = ['silver_vars']
+    tags = get_path_tags(model)
 ) }}
 
 SELECT

--- a/models/reads_package/bronze/bronze__reads.sql
+++ b/models/reads_package/bronze/bronze__reads.sql
@@ -19,7 +19,7 @@
 {# Set up dbt configuration #}
 {{ config (
     materialized = 'view',
-    tags = ['bronze_reads']
+    tags = get_path_tags(model)
 ) }}
 
 {# Main query starts here #}

--- a/models/reads_package/bronze/bronze__reads_fr.sql
+++ b/models/reads_package/bronze/bronze__reads_fr.sql
@@ -3,7 +3,7 @@
 
 {{ config (
     materialized = 'view',
-    tags = ['bronze_reads']
+    tags = get_path_tags(model)
 ) }}
 
 SELECT

--- a/models/reads_package/bronze/bronze__reads_fr_v1.sql
+++ b/models/reads_package/bronze/bronze__reads_fr_v1.sql
@@ -19,7 +19,7 @@
 {# Set up dbt configuration #}
 {{ config (
     materialized = 'view',
-    tags = ['bronze_reads_streamline_v1']
+    tags = get_path_tags(model)
 ) }}
 
 {# Main query starts here #}

--- a/models/reads_package/bronze/bronze__reads_fr_v2.sql
+++ b/models/reads_package/bronze/bronze__reads_fr_v2.sql
@@ -19,7 +19,7 @@
 {# Set up dbt configuration #}
 {{ config (
     materialized = 'view',
-    tags = ['bronze_reads']
+    tags = get_path_tags(model)
 ) }}
 
 {# Main query starts here #}

--- a/models/reads_package/streamline/complete/streamline__reads_complete.sql
+++ b/models/reads_package/streamline/complete/streamline__reads_complete.sql
@@ -20,7 +20,7 @@
     merge_update_columns = ["complete_reads_id"],
     post_hook = post_hook,
     full_refresh = full_refresh_type,
-    tags = ['streamline_reads_complete']
+    tags = get_path_tags(model)
 ) }}
 
 {# Main query starts here #}

--- a/models/reads_package/streamline/history/streamline__reads_history.sql
+++ b/models/reads_package/streamline/history/streamline__reads_history.sql
@@ -35,7 +35,7 @@
         target = "{{this.schema}}.{{this.identifier}}",
         params = streamline_params
     ),
-    tags = ['streamline_reads_history']
+    tags = get_path_tags(model)
 ) }}
 
 {# Main query starts here #}

--- a/models/reads_package/streamline/realtime/streamline__reads_realtime.sql
+++ b/models/reads_package/streamline/realtime/streamline__reads_realtime.sql
@@ -35,7 +35,7 @@
         target = "{{this.schema}}.{{this.identifier}}",
         params = streamline_params
     ),
-    tags = ['streamline_reads_realtime']
+    tags = get_path_tags(model)
 ) }}
 
 {# Main query starts here #}

--- a/models/scores_package/scores__actions.sql
+++ b/models/scores_package/scores__actions.sql
@@ -10,7 +10,7 @@
     incremental_strategy = "delete+insert",
     cluster_by = "block_date",
     full_refresh = false,
-    tags = ['scores']
+    tags = get_path_tags(model)
 ) }}
 
 {% if is_incremental() %}

--- a/models/scores_package/scores__actions_agg.sql
+++ b/models/scores_package/scores__actions_agg.sql
@@ -16,7 +16,7 @@
     cluster_by = "score_date",
     version = 1,
     full_refresh = false,
-    tags = ['scores']
+    tags = get_path_tags(model)
 ) }}
 
     {% set score_dates_query %}

--- a/models/scores_package/scores__actions_daily.sql
+++ b/models/scores_package/scores__actions_daily.sql
@@ -10,7 +10,7 @@
     incremental_strategy = "delete+insert",
     cluster_by = "block_date",
     version = 1,
-    tags = ['scores']
+    tags = get_path_tags(model)
 ) }}
 
     {% if is_incremental() %}

--- a/models/scores_package/scores__dates.sql
+++ b/models/scores_package/scores__dates.sql
@@ -3,7 +3,7 @@
 
 {{ config (
     materialized = "view",
-    tags = ['scores']
+    tags = get_path_tags(model)
 ) }}
 
 select * from {{ source('data_science_silver', 'dates') }}

--- a/models/scores_package/scores__event_sigs.sql
+++ b/models/scores_package/scores__event_sigs.sql
@@ -3,7 +3,7 @@
 
 {{ config (
     materialized = "view",
-    tags = ['scores']
+    tags = get_path_tags(model)
 ) }}
 
 select * from {{ source('data_science_silver', 'evm_event_sigs') }}

--- a/models/scores_package/scores__known_event_names.sql
+++ b/models/scores_package/scores__known_event_names.sql
@@ -3,7 +3,7 @@
 
 {{ config (
     materialized = "view",
-    tags = ['scores']
+    tags = get_path_tags(model)
 ) }}
 
 select * from {{ source('data_science_silver', 'evm_known_event_names') }}

--- a/models/scores_package/scores__known_event_sigs.sql
+++ b/models/scores_package/scores__known_event_sigs.sql
@@ -3,7 +3,7 @@
 
 {{ config (
     materialized = "view",
-    tags = ['scores']
+    tags = get_path_tags(model)
 ) }}
 
 select * from {{ source('data_science_silver', 'evm_known_event_sigs') }}

--- a/models/scores_package/scores__scoring_activity_categories.sql
+++ b/models/scores_package/scores__scoring_activity_categories.sql
@@ -3,7 +3,7 @@
 
 {{ config (
     materialized = "view",
-    tags = ['scores']
+    tags = get_path_tags(model)
 ) }}
 
 select * from {{ source('data_science_silver', 'scoring_activity_categories') }}

--- a/models/scores_package/scores__target_days.sql
+++ b/models/scores_package/scores__target_days.sql
@@ -5,7 +5,7 @@
 
 {{ config (
     materialized = "view",
-    tags = ['scores']
+    tags = get_path_tags(model)
 ) }}
 
 {% if execute %}

--- a/models/scores_package/scores__wrapped_assets.sql
+++ b/models/scores_package/scores__wrapped_assets.sql
@@ -3,7 +3,7 @@
 
 {{ config (
     materialized = "view",
-    tags = ['scores']
+    tags = get_path_tags(model)
 ) }}
 
 select * from {{ source('data_science_silver', 'evm_wrapped_assets') }}

--- a/selectors.yml
+++ b/selectors.yml
@@ -1,0 +1,35 @@
+selectors:
+  - name: recent_tests
+    description: "All recent tests"
+    definition:
+      test_name:*recent*
+
+  - name: unique_tests
+    description: "All unique tests"
+    definition:
+      test_name:*unique*
+
+  - name: null_tests
+    description: "All null tests"
+    definition:
+      test_name:*null*
+
+  - name: other_tests
+    description: "Tests that don't match recent, unique, or null patterns"
+    definition:
+      union:
+        - test_type: generic
+        - test_type: singular
+        - exclude:
+            - test_name:*recent*
+            - test_name:*unique*
+            - test_name:*null*
+  
+  - name: non_recent_tests
+    description: "Tests that don't match recent patterns"
+    definition:
+      union:
+        - test_type: generic
+        - test_type: singular
+        - exclude:
+            - test_name:*recent*

--- a/selectors.yml
+++ b/selectors.yml
@@ -33,3 +33,26 @@ selectors:
         - test_type: singular
         - exclude:
             - test_name:*recent*
+
+  - name: main
+    description: "Main GHA scheduled run"
+    definition:
+      method: tag
+      value: main_package
+      exclude:
+        - tag:streamline
+        - tag:github_actions
+        - tag:tests
+        - intersection:
+            - tag:prices
+            - tag:bronze
+        - tag:observability
+
+  - name: send_logs
+    description: "Streamline decoded logs run"
+    definition:
+      union:
+        - intersection:
+            - tag:decoded_logs
+            - tag:streamline
+        - tag:bronze__decoded_logs

--- a/selectors.yml
+++ b/selectors.yml
@@ -56,3 +56,13 @@ selectors:
             - tag:decoded_logs
             - tag:streamline
         - tag:bronze__decoded_logs
+
+  - name: get_abis
+    description: "ABI models"
+    definition:
+      union:
+        - tag:bronze__contract_abis
+        - tag:bronze__contract_abis_fr
+        - intersection:
+            - tag:abis
+            - tag:streamline


### PR DESCRIPTION
1. Adds automated tag generation macro based on file path
   - Replaces all tag configs with macro ref `tags = get_path_tags(model)`
   - `fsc_evm/models/main_package/labels/bronze/bronze__labels.sql`will be auto-tagged with:
``` 
"tags": [
    "main_package",
    "labels",
    "bronze",
    "bronze__labels"
  ] 
```
3. Adds `tag_mapping` macro
   - Here you can add tags to tags, ie `reorg` can be added to all `defi` folder tags or `bronze__labels` can have a `phase_2` tag applied
   - Less important now that we have selectors built out
2. Adds `selectors.yml` for run commands
   - Main run command will now be`dbt run --selector main`
   - All command logic is stored within the `selectors.yml`
   - In order to run `selectors.yml` needs to be in root directory. Added two make commands to account for this:
      - `make copy_selectors`: this command will copy the `selectors.yml` from fsc_evm package into the root repo directory
      - `make append_selectors`: this command will append the root directories selector doc to the fsc_evm doc under the root directory. Giving us the ability to add repo specific selectors
   - Need to add `include dbt_packages/fsc_evm/makefile` to top of repo make files