### PR TITLE
AN-5839/fsc-evm-v4-tags

### DIFF
--- a/macros/tags/model_tags/get_tags.sql
+++ b/macros/tags/model_tags/get_tags.sql
@@ -1,0 +1,39 @@
+{%- macro load_tag_mapping() -%}
+    {% set tag_mapping = get_tag_dictionary() %}
+    {{ return(tag_mapping) }}
+{%- endmacro -%}
+
+{%- macro get_path_tags(model) -%}
+    {% set tags = [] %}
+
+    {% set path_str = model.original_file_path | string %}
+    {% set path = path_str.split('/') %}
+
+    {# Skip 'models' directory if it exists #}
+    {% set start_index = 1 if path[0] == 'models' else 0 %}
+
+    {# Process each directory in the path #}
+    {% for part in path[start_index:-1] %}
+        {% do tags.append(part) %}
+    {% endfor %}
+
+    {# Process the filename without extension #}
+    {% set filename = path[-1] | replace('.sql', '') | replace('.yml', '') %}
+
+    {# Add the full filename as a tag #}
+    {% do tags.append(filename) %}
+
+    {# Load tag mapping from YAML #}
+    {% set tag_mapping = load_tag_mapping() %}
+
+    {# Apply tag mapping rules #}
+    {% set final_tags = tags.copy() %}
+    {% for tag in tags %}
+        {% if tag in tag_mapping %}
+            {% do final_tags.extend(tag_mapping[tag]) %}
+        {% endif %}
+    {% endfor %}
+
+    {# Return unique tags to avoid duplicates #}
+    {{ return(final_tags | unique | list) }}
+{%- endmacro -%}

--- a/macros/tags/model_tags/tag_mapping.sql
+++ b/macros/tags/model_tags/tag_mapping.sql
@@ -1,0 +1,12 @@
+{#
+    Sets folder level tags, which will be inherited by all models in that folder
+#}
+{%- macro get_tag_dictionary() -%}
+    {% set tag_mapping = {
+
+        'defi': ['curated', 'reorg'],
+        'protocols': ['curated', 'reorg']
+    } %}
+
+    {{ return(tag_mapping) }}
+{%- endmacro -%}

--- a/macros/tests/dynamic_tests.sql
+++ b/macros/tests/dynamic_tests.sql
@@ -32,7 +32,7 @@
         filter_condition = none
     ) -%}
 
-    {% if where %}
+    {% if where and interval_vars.interval_type is not none and interval_vars.interval_value is not none %}
         {% if "__timestamp_filter__" in where %}
             {% set columns = adapter.get_columns_in_relation(relation) %}
             {% set column_names = columns | map(attribute='name') | list %}

--- a/makefile
+++ b/makefile
@@ -1,5 +1,3 @@
-.PHONY: new_repo_tag
-
 new_repo_tag:
 	@echo "Last 3 tags:"
 	@git tag -l --sort=-v:refname | head -n 3
@@ -27,3 +25,27 @@ new_repo_tag:
 	else \
 		echo "No tag name entered. Operation cancelled."; \
 	fi
+copy-selectors:
+	@if [ -f dbt_packages/fsc_evm/selectors.yml ]; then \
+		cp dbt_packages/fsc_evm/selectors.yml ./selectors.yml && \
+		echo "Successfully copied selectors.yml to project root"; \
+	else \
+		echo "Error: dbt_packages/fsc_evm/selectors.yml not found"; \
+		exit 1; \
+	fi
+append-selectors:
+	@if [ -f dbt_packages/fsc_evm/selectors.yml ] && [ -f selectors.yml ]; then \
+		echo "Merging selectors..."; \
+		awk 'BEGIN {p=1} \
+			/^selectors:/ {if(p==1) {print; p=0; next}} \
+			p==1 {print} \
+			/^selectors:/ {p=0; next} \
+			p==0 {print}' selectors.yml > selectors_temp.yml && \
+		awk '/^selectors:/ {next} {print}' dbt_packages/fsc_evm/selectors.yml >> selectors_temp.yml && \
+		mv selectors_temp.yml selectors.yml && \
+		echo "Successfully merged selectors"; \
+	else \
+		echo "Error: One or both selector files not found"; \
+		exit 1; \
+	fi
+.PHONY: new_repo_tag copy-selectors append-selectors

--- a/models/curated_package/protocols/vertex/gold/vertex__ez_account_stats.sql
+++ b/models/curated_package/protocols/vertex/gold/vertex__ez_account_stats.sql
@@ -5,7 +5,7 @@
     materialized = 'view',
     meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'CLOB, DEX, STATS',
     } } },
-    tags = ['curated', 'gold_vertex']
+    tags = get_path_tags(model)
 ) }}
 
 SELECT

--- a/models/curated_package/protocols/vertex/gold/vertex__ez_clearing_house_events.sql
+++ b/models/curated_package/protocols/vertex/gold/vertex__ez_clearing_house_events.sql
@@ -6,7 +6,7 @@
     unique_key = 'ez_clearing_house_events_id',
     merge_exclude_columns = ["inserted_timestamp"],
     post_hook = "ALTER TABLE {{ this }} ADD SEARCH OPTIMIZATION ON EQUALITY(trader, symbol, subaccount), SUBSTRING(subaccount, symbol)",
-    tags = ['curated', 'gold_vertex']
+    tags = get_path_tags(model)
 ) }}
 
 SELECT

--- a/models/curated_package/protocols/vertex/gold/vertex__ez_edge_trades.sql
+++ b/models/curated_package/protocols/vertex/gold/vertex__ez_edge_trades.sql
@@ -6,7 +6,7 @@
     unique_key = 'ez_edge_trades_id',
     merge_exclude_columns = ["inserted_timestamp"],
     post_hook = "ALTER TABLE {{ this }} ADD SEARCH OPTIMIZATION ON EQUALITY(trader, symbol, subaccount), SUBSTRING(subaccount, symbol)",
-    tags = ['curated', 'gold_vertex']
+    tags = get_path_tags(model)
 ) }}
 
 SELECT

--- a/models/curated_package/protocols/vertex/gold/vertex__ez_liquidations.sql
+++ b/models/curated_package/protocols/vertex/gold/vertex__ez_liquidations.sql
@@ -6,7 +6,7 @@
     unique_key = 'ez_liquidations_id',
     merge_exclude_columns = ["inserted_timestamp"],
     post_hook = "ALTER TABLE {{ this }} ADD SEARCH OPTIMIZATION ON EQUALITY(trader, subaccount,digest), SUBSTRING(subaccount,trader)",
-    tags = ['curated', 'gold_vertex']
+    tags = get_path_tags(model)
 ) }}
 
 SELECT

--- a/models/curated_package/protocols/vertex/gold/vertex__ez_market_depth_stats.sql
+++ b/models/curated_package/protocols/vertex/gold/vertex__ez_market_depth_stats.sql
@@ -6,7 +6,7 @@
     unique_key = 'ez_market_depth_stats_id',
     merge_exclude_columns = ["inserted_timestamp"],
     post_hook = "ALTER TABLE {{ this }} ADD SEARCH OPTIMIZATION ON EQUALITY(ticker_id,product_id), SUBSTRING(ticker_id,product_id)",
-    tags = ['curated', 'gold_vertex']
+    tags = get_path_tags(model)
 ) }}
 
 SELECT

--- a/models/curated_package/protocols/vertex/gold/vertex__ez_market_stats.sql
+++ b/models/curated_package/protocols/vertex/gold/vertex__ez_market_stats.sql
@@ -6,7 +6,7 @@
     unique_key = 'ez_market_stats_id',
     merge_exclude_columns = ["inserted_timestamp"],
     post_hook = "ALTER TABLE {{ this }} ADD SEARCH OPTIMIZATION ON EQUALITY(ticker_id,product_id,symbol), SUBSTRING(ticker_id,product_id,symbol)",
-    tags = ['curated', 'gold_vertex']
+    tags = get_path_tags(model)
 ) }}
 
 SELECT

--- a/models/curated_package/protocols/vertex/gold/vertex__ez_money_markets.sql
+++ b/models/curated_package/protocols/vertex/gold/vertex__ez_money_markets.sql
@@ -6,7 +6,7 @@
     unique_key = 'ez_money_markets_id',
     merge_exclude_columns = ["inserted_timestamp"],
     post_hook = "ALTER TABLE {{ this }} ADD SEARCH OPTIMIZATION ON EQUALITY(ticker_id,product_id,symbol), SUBSTRING(ticker_id,product_id,symbol)",
-    tags = ['curated', 'gold_vertex']
+    tags = get_path_tags(model)
 ) }}
 
 SELECT

--- a/models/curated_package/protocols/vertex/gold/vertex__ez_perp_trades.sql
+++ b/models/curated_package/protocols/vertex/gold/vertex__ez_perp_trades.sql
@@ -6,7 +6,7 @@
     unique_key = 'ez_perp_trades_id',
     merge_exclude_columns = ["inserted_timestamp"],
     post_hook = "ALTER TABLE {{ this }} ADD SEARCH OPTIMIZATION ON EQUALITY(tx_hash,symbol,trader,digest,subaccount), SUBSTRING(symbol,trader)",
-    tags = ['curated', 'gold_vertex']
+    tags = get_path_tags(model)
 ) }}
 
 

--- a/models/curated_package/protocols/vertex/gold/vertex__ez_spot_trades.sql
+++ b/models/curated_package/protocols/vertex/gold/vertex__ez_spot_trades.sql
@@ -6,7 +6,7 @@
     unique_key = 'ez_spot_trades_id',
     merge_exclude_columns = ["inserted_timestamp"],
     post_hook = "ALTER TABLE {{ this }} ADD SEARCH OPTIMIZATION ON EQUALITY(tx_hash,symbol,trader,digest,subaccount), SUBSTRING(symbol,trader)",
-    tags = ['curated', 'gold_vertex']
+    tags = get_path_tags(model)
 ) }}
 
 SELECT

--- a/models/curated_package/protocols/vertex/silver/silver__vertex_account_stats.sql
+++ b/models/curated_package/protocols/vertex/silver/silver__vertex_account_stats.sql
@@ -5,7 +5,7 @@
     materialized = 'incremental',
     incremental_strategy = 'delete+insert',
     unique_key = 'subaccount',
-    tags = 'curated'
+    tags = get_path_tags(model)
 ) }}
 
 WITH

--- a/models/curated_package/protocols/vertex/silver/silver__vertex_collateral.sql
+++ b/models/curated_package/protocols/vertex/silver/silver__vertex_collateral.sql
@@ -9,7 +9,7 @@
     incremental_strategy = 'delete+insert',
     unique_key = 'fact_event_logs_id',
     cluster_by = ['block_timestamp::DATE'],
-    tags = ['curated','reorg'],
+    tags = get_path_tags(model),
     enabled = false
 ) }}
 

--- a/models/curated_package/protocols/vertex/silver/silver__vertex_dim_products.sql
+++ b/models/curated_package/protocols/vertex/silver/silver__vertex_dim_products.sql
@@ -9,7 +9,7 @@
     incremental_strategy = 'delete+insert',
     unique_key = 'product_id',
     cluster_by = ['block_timestamp::DATE'],
-    tags = ['curated','reorg']
+    tags = get_path_tags(model)
 ) }}
 
 

--- a/models/curated_package/protocols/vertex/silver/silver__vertex_edge_trades.sql
+++ b/models/curated_package/protocols/vertex/silver/silver__vertex_edge_trades.sql
@@ -6,7 +6,7 @@
     incremental_strategy = 'delete+insert',
     unique_key = 'fact_event_logs_id',
     cluster_by = ['block_timestamp::DATE'],
-    tags = ['curated','reorg']
+    tags = get_path_tags(model)
 ) }}
 
 

--- a/models/curated_package/protocols/vertex/silver/silver__vertex_liquidations.sql
+++ b/models/curated_package/protocols/vertex/silver/silver__vertex_liquidations.sql
@@ -9,7 +9,7 @@
     incremental_strategy = 'delete+insert',
     unique_key = 'fact_event_logs_id',
     cluster_by = ['block_timestamp::DATE'],
-    tags = ['curated','reorg']
+    tags = get_path_tags(model)
 ) }}
 
 

--- a/models/curated_package/protocols/vertex/silver/silver__vertex_market_depth.sql
+++ b/models/curated_package/protocols/vertex/silver/silver__vertex_market_depth.sql
@@ -10,7 +10,7 @@
     full_refresh = false,
     unique_key = ['product_id','hour','price'],
     cluster_by = ['hour::DATE'],
-    tags = 'curated'
+    tags = get_path_tags(model)
 ) }}
 
 WITH market_depth AS ({% for item in range(55) %}

--- a/models/curated_package/protocols/vertex/silver/silver__vertex_market_stats.sql
+++ b/models/curated_package/protocols/vertex/silver/silver__vertex_market_stats.sql
@@ -9,7 +9,7 @@
     incremental_strategy = 'merge',
     unique_key = ['ticker_id','hour'],
     cluster_by = ['HOUR::DATE'],
-    tags = 'curated'
+    tags = get_path_tags(model)
 ) }}
 
 

--- a/models/curated_package/protocols/vertex/silver/silver__vertex_money_markets.sql
+++ b/models/curated_package/protocols/vertex/silver/silver__vertex_money_markets.sql
@@ -9,7 +9,7 @@
     incremental_strategy = 'merge',
     unique_key = ['ticker_id','hour'],
     cluster_by = ['HOUR::DATE'],
-    tags = 'curated'
+    tags = get_path_tags(model)
 ) }}
 
 

--- a/models/curated_package/protocols/vertex/silver/silver__vertex_perps.sql
+++ b/models/curated_package/protocols/vertex/silver/silver__vertex_perps.sql
@@ -9,7 +9,7 @@
     incremental_strategy = 'delete+insert',
     unique_key = 'fact_event_logs_id',
     cluster_by = ['block_timestamp::DATE'],
-    tags = ['curated','reorg']
+    tags = get_path_tags(model)
 ) }}
 
 

--- a/models/curated_package/protocols/vertex/silver/silver__vertex_spot.sql
+++ b/models/curated_package/protocols/vertex/silver/silver__vertex_spot.sql
@@ -9,7 +9,7 @@
     incremental_strategy = 'delete+insert',
     unique_key = 'fact_event_logs_id',
     cluster_by = ['block_timestamp::DATE'],
-    tags = ['curated','reorg']
+    tags = get_path_tags(model)
 ) }}
 
 

--- a/models/curated_package/stats/gold/stats__ez_core_metrics_hourly.sql
+++ b/models/curated_package/stats/gold/stats__ez_core_metrics_hourly.sql
@@ -9,7 +9,7 @@
     materialized = 'view',
     meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'STATS, METRICS, CORE, HOURLY',
     } } },
-    tags = ['curated', 'gold_stats']
+    tags = get_path_tags(model)
 ) }}
 
 {# Main query starts here #}

--- a/models/curated_package/stats/silver/silver_stats__core_metrics_hourly.sql
+++ b/models/curated_package/stats/silver/silver_stats__core_metrics_hourly.sql
@@ -7,7 +7,7 @@
     incremental_strategy = 'delete+insert',
     unique_key = "block_timestamp_hour",
     cluster_by = ['block_timestamp_hour::DATE'],
-    tags = ['curated', 'silver_stats', 'daily_test']
+    tags = get_path_tags(model)
 ) }}
 
 {# run incremental timestamp value first then use it as a static value #}

--- a/models/decoder_package/abis/bronze/bronze_api__contract_abis.sql
+++ b/models/decoder_package/abis/bronze/bronze_api__contract_abis.sql
@@ -11,7 +11,7 @@
     unique_key = "contract_address",
     post_hook = "ALTER TABLE {{ this }} ADD SEARCH OPTIMIZATION on equality(contract_address)",
     full_refresh = vars.GLOBAL_BRONZE_FR_ENABLED,
-    tags = ['bronze_abis']
+    tags = get_path_tags(model)
 ) }}
 
 WITH base AS (

--- a/models/decoder_package/abis/bronze/tests/test_bronze__contract_abis_full.sql
+++ b/models/decoder_package/abis/bronze/tests/test_bronze__contract_abis_full.sql
@@ -3,7 +3,7 @@
 
 {{ config (
     materialized = "view",
-    tags = ['full_test']
+    tags = get_path_tags(model)
 ) }}
 
 SELECT

--- a/models/decoder_package/abis/bronze/tests/test_bronze__contract_abis_recent.sql
+++ b/models/decoder_package/abis/bronze/tests/test_bronze__contract_abis_recent.sql
@@ -3,7 +3,7 @@
 
 {{ config (
     materialized = "view",
-    tags = ['daily_test']
+    tags = get_path_tags(model)
 ) }}
 
 SELECT

--- a/models/decoder_package/abis/gold/core__dim_contract_abis.sql
+++ b/models/decoder_package/abis/gold/core__dim_contract_abis.sql
@@ -6,7 +6,7 @@
     unique_key = "contract_address",
     merge_exclude_columns = ["inserted_timestamp"],
     post_hook = "ALTER TABLE {{ this }} ADD SEARCH OPTIMIZATION ON EQUALITY(contract_address,bytecode), SUBSTRING(contract_address,bytecode)",
-    tags = ['gold_abis']
+    tags = get_path_tags(model)
 ) }}
 
 SELECT

--- a/models/decoder_package/abis/gold/tests/test_gold__dim_contract_abis_full.sql
+++ b/models/decoder_package/abis/gold/tests/test_gold__dim_contract_abis_full.sql
@@ -3,7 +3,7 @@
 
 {{ config (
     materialized = "view",
-    tags = ['full_test']
+    tags = get_path_tags(model)
 ) }}
 
 SELECT

--- a/models/decoder_package/abis/gold/tests/test_gold__dim_contract_abis_recent.sql
+++ b/models/decoder_package/abis/gold/tests/test_gold__dim_contract_abis_recent.sql
@@ -3,7 +3,7 @@
 
 {{ config (
     materialized = "view",
-    tags = ['daily_test']
+    tags = get_path_tags(model)
 ) }}
 
 SELECT

--- a/models/decoder_package/abis/silver/silver__abis.sql
+++ b/models/decoder_package/abis/silver/silver__abis.sql
@@ -9,7 +9,7 @@
     unique_key = "contract_address",
     merge_exclude_columns = ["inserted_timestamp"],
     post_hook = "ALTER TABLE {{ this }} ADD SEARCH OPTIMIZATION ON EQUALITY(contract_address,abi_hash,bytecode), SUBSTRING(contract_address,abi_hash,bytecode)",
-    tags = ['silver_abis']
+    tags = get_path_tags(model)
 ) }}
 
 WITH verified_abis AS (

--- a/models/decoder_package/abis/silver/silver__bytecode_abis.sql
+++ b/models/decoder_package/abis/silver/silver__bytecode_abis.sql
@@ -4,7 +4,7 @@
 {{ config (
     materialized = "incremental",
     unique_key = "contract_address",
-    tags = ['silver_abis']
+    tags = get_path_tags(model)
 ) }}
 
 WITH contracts_with_abis AS (

--- a/models/decoder_package/abis/silver/silver__complete_event_abis.sql
+++ b/models/decoder_package/abis/silver/silver__complete_event_abis.sql
@@ -6,7 +6,7 @@
     unique_key = ["parent_contract_address","event_signature","start_block"],
     merge_exclude_columns = ["inserted_timestamp"],
     post_hook = "ALTER TABLE {{ this }} ADD SEARCH OPTIMIZATION",
-    tags = ['silver_abis']
+    tags = get_path_tags(model)
 ) }}
 
 WITH new_abis AS (

--- a/models/decoder_package/abis/silver/silver__flat_event_abis.sql
+++ b/models/decoder_package/abis/silver/silver__flat_event_abis.sql
@@ -7,7 +7,7 @@
     unique_key = "contract_address",
     cluster_by = "_inserted_timestamp::date",
     post_hook = "ALTER TABLE {{ this }} ADD SEARCH OPTIMIZATION ON EQUALITY (contract_address)",
-    tags = ['silver_abis']
+    tags = get_path_tags(model)
 ) }}
 
 WITH abi_base AS (

--- a/models/decoder_package/abis/silver/silver__user_verified_abis.sql
+++ b/models/decoder_package/abis/silver/silver__user_verified_abis.sql
@@ -7,7 +7,7 @@
 {{ config (
     materialized = "incremental",
     unique_key = "id",
-    tags = ['silver_abis']
+    tags = get_path_tags(model)
 ) }}
 
 WITH base AS (

--- a/models/decoder_package/abis/silver/silver__verified_abis.sql
+++ b/models/decoder_package/abis/silver/silver__verified_abis.sql
@@ -9,7 +9,7 @@
     unique_key = "contract_address",
     merge_update_columns = ["contract_address"],
     post_hook = "ALTER TABLE {{ this }} ADD SEARCH OPTIMIZATION on equality(contract_address)",
-    tags = ['silver_abis']
+    tags = get_path_tags(model)
 ) }}
 
 WITH base AS (

--- a/models/decoder_package/abis/silver/tests/abis/test_silver__abis_full.sql
+++ b/models/decoder_package/abis/silver/tests/abis/test_silver__abis_full.sql
@@ -3,7 +3,7 @@
 
 {{ config (
     materialized = "view",
-    tags = ['full_test']
+    tags = get_path_tags(model)
 ) }}
 
 SELECT

--- a/models/decoder_package/abis/silver/tests/abis/test_silver__abis_recent.sql
+++ b/models/decoder_package/abis/silver/tests/abis/test_silver__abis_recent.sql
@@ -3,7 +3,7 @@
 
 {{ config (
     materialized = "view",
-    tags = ['daily_test']
+    tags = get_path_tags(model)
 ) }}
 
 SELECT

--- a/models/decoder_package/abis/silver/tests/bytecode_abis/test_silver__bytecode_abis_full.sql
+++ b/models/decoder_package/abis/silver/tests/bytecode_abis/test_silver__bytecode_abis_full.sql
@@ -3,7 +3,7 @@
 
 {{ config (
     materialized = "view",
-    tags = ['full_test']
+    tags = get_path_tags(model)
 ) }}
 
 SELECT

--- a/models/decoder_package/abis/silver/tests/bytecode_abis/test_silver__bytecode_abis_recent.sql
+++ b/models/decoder_package/abis/silver/tests/bytecode_abis/test_silver__bytecode_abis_recent.sql
@@ -3,7 +3,7 @@
 
 {{ config (
     materialized = "view",
-    tags = ['daily_test']
+    tags = get_path_tags(model)
 ) }}
 
 SELECT

--- a/models/decoder_package/abis/silver/tests/event_abis/test_silver__complete_event_abis_full.sql
+++ b/models/decoder_package/abis/silver/tests/event_abis/test_silver__complete_event_abis_full.sql
@@ -3,7 +3,7 @@
 
 {{ config (
     materialized = "view",
-    tags = ['full_test']
+    tags = get_path_tags(model)
 ) }}
 
 SELECT

--- a/models/decoder_package/abis/silver/tests/event_abis/test_silver__complete_event_abis_recent.sql
+++ b/models/decoder_package/abis/silver/tests/event_abis/test_silver__complete_event_abis_recent.sql
@@ -3,7 +3,7 @@
 
 {{ config (
     materialized = "view",
-    tags = ['daily_test']
+    tags = get_path_tags(model)
 ) }}
 
 SELECT

--- a/models/decoder_package/abis/silver/tests/user_verified_abis/test_silver__user_verified_abis_full.sql
+++ b/models/decoder_package/abis/silver/tests/user_verified_abis/test_silver__user_verified_abis_full.sql
@@ -3,7 +3,7 @@
 
 {{ config (
     materialized = "view",
-    tags = ['full_test']
+    tags = get_path_tags(model)
 ) }}
 
 SELECT

--- a/models/decoder_package/abis/silver/tests/user_verified_abis/test_silver__user_verified_abis_recent.sql
+++ b/models/decoder_package/abis/silver/tests/user_verified_abis/test_silver__user_verified_abis_recent.sql
@@ -3,7 +3,7 @@
 
 {{ config (
     materialized = "view",
-    tags = ['daily_test']
+    tags = get_path_tags(model)
 ) }}
 
 SELECT

--- a/models/decoder_package/abis/silver/tests/verified_abis/test_silver__verified_abis_full.sql
+++ b/models/decoder_package/abis/silver/tests/verified_abis/test_silver__verified_abis_full.sql
@@ -3,7 +3,7 @@
 
 {{ config (
     materialized = "view",
-    tags = ['full_test']
+    tags = get_path_tags(model)
 ) }}
 
 SELECT

--- a/models/decoder_package/abis/silver/tests/verified_abis/test_silver__verified_abis_recent.sql
+++ b/models/decoder_package/abis/silver/tests/verified_abis/test_silver__verified_abis_recent.sql
@@ -3,7 +3,7 @@
 
 {{ config (
     materialized = "view",
-    tags = ['daily_test']
+    tags = get_path_tags(model)
 ) }}
 
 SELECT

--- a/models/decoder_package/decoded_logs/bronze/bronze__decoded_logs.sql
+++ b/models/decoder_package/decoded_logs/bronze/bronze__decoded_logs.sql
@@ -4,7 +4,7 @@
 {# Set up dbt configuration #}
 {{ config (
     materialized = 'view',
-    tags = ['bronze_decoded_logs']
+    tags = get_path_tags(model)
 ) }}
 
 {# Main query starts here #}

--- a/models/decoder_package/decoded_logs/bronze/bronze__decoded_logs_fr.sql
+++ b/models/decoder_package/decoded_logs/bronze/bronze__decoded_logs_fr.sql
@@ -4,7 +4,7 @@
 {# Set up dbt configuration #}
 {{ config (
     materialized = 'view',
-    tags = ['bronze_decoded_logs']
+    tags = get_path_tags(model)
 ) }}
 
 {# Main query starts here #}

--- a/models/decoder_package/decoded_logs/gold/core__ez_decoded_event_logs.sql
+++ b/models/decoder_package/decoded_logs/gold/core__ez_decoded_event_logs.sql
@@ -12,7 +12,7 @@
     incremental_predicates = [fsc_evm.standard_predicate()],
     full_refresh = vars.GLOBAL_GOLD_FR_ENABLED,
     post_hook = 'ALTER TABLE {{ this }} ADD SEARCH OPTIMIZATION ON EQUALITY(ez_decoded_event_logs_id, contract_name, contract_address)',
-    tags = ['gold_decoded_logs']
+    tags = get_path_tags(model)
 ) }}
 
 WITH base AS (

--- a/models/decoder_package/decoded_logs/gold/tests/test_gold__ez_decoded_event_logs_full.sql
+++ b/models/decoder_package/decoded_logs/gold/tests/test_gold__ez_decoded_event_logs_full.sql
@@ -3,7 +3,7 @@
 
 {{ config (
     materialized = "view",
-    tags = ['full_test']
+    tags = get_path_tags(model)
 ) }}
 
 SELECT

--- a/models/decoder_package/decoded_logs/gold/tests/test_gold__ez_decoded_event_logs_recent.sql
+++ b/models/decoder_package/decoded_logs/gold/tests/test_gold__ez_decoded_event_logs_recent.sql
@@ -3,7 +3,7 @@
 
 {{ config (
     materialized = "view",
-    tags = ['recent_test']
+    tags = get_path_tags(model)
 ) }}
 
 SELECT

--- a/models/decoder_package/decoded_logs/silver/silver__decoded_logs.sql
+++ b/models/decoder_package/decoded_logs/silver/silver__decoded_logs.sql
@@ -13,7 +13,7 @@
     cluster_by = ['modified_timestamp::date', 'round(block_number, -3)'],
     incremental_predicates = [fsc_evm.standard_predicate()],
     full_refresh = vars.GLOBAL_SILVER_FR_ENABLED,
-    tags = ['silver_decoded_logs']
+    tags = get_path_tags(model)
 ) }}
 
 WITH base_data AS (

--- a/models/decoder_package/decoded_logs/silver/tests/test_silver__decoded_logs_full.sql
+++ b/models/decoder_package/decoded_logs/silver/tests/test_silver__decoded_logs_full.sql
@@ -3,7 +3,7 @@
 
 {{ config (
     materialized = "view",
-    tags = ['full_test']
+    tags = get_path_tags(model)
 ) }}
 
 SELECT

--- a/models/decoder_package/decoded_logs/silver/tests/test_silver__decoded_logs_recent.sql
+++ b/models/decoder_package/decoded_logs/silver/tests/test_silver__decoded_logs_recent.sql
@@ -3,7 +3,7 @@
 
 {{ config (
     materialized = "view",
-    tags = ['recent_test']
+    tags = get_path_tags(model)
 ) }}
 
 SELECT

--- a/models/decoder_package/decoded_logs/streamline/complete/streamline__decoded_logs_complete.sql
+++ b/models/decoder_package/decoded_logs/streamline/complete/streamline__decoded_logs_complete.sql
@@ -15,7 +15,7 @@
     merge_update_columns = ["_log_id"],
     post_hook = "ALTER TABLE {{ this }} ADD SEARCH OPTIMIZATION on equality(_log_id)",
     full_refresh = vars.GLOBAL_STREAMLINE_FR_ENABLED,
-    tags = ['streamline_decoded_logs_complete']
+    tags = get_path_tags(model)
 ) }}
 
 {# Main query starts here #}

--- a/models/decoder_package/decoded_logs/streamline/realtime/streamline__decoded_logs_realtime.sql
+++ b/models/decoder_package/decoded_logs/streamline/realtime/streamline__decoded_logs_realtime.sql
@@ -19,7 +19,7 @@
         } 
     ), 
     fsc_utils.if_data_call_wait()],
-    tags = ['streamline_decoded_logs_realtime']
+    tags = get_path_tags(model)
 ) }}
 
 WITH target_blocks AS (

--- a/models/main_package/core/bronze/streamline/bronze__blocks.sql
+++ b/models/main_package/core/bronze/streamline/bronze__blocks.sql
@@ -4,7 +4,7 @@
 {# Set up dbt configuration #}
 {{ config (
     materialized = 'view',
-    tags = ['bronze_core']
+    tags = get_path_tags(model)
 ) }}
 
 {# Main query starts here #}

--- a/models/main_package/core/bronze/streamline/bronze__blocks_fr.sql
+++ b/models/main_package/core/bronze/streamline/bronze__blocks_fr.sql
@@ -4,7 +4,7 @@
 {# Set up dbt configuration #}
 {{ config (
     materialized = 'view',
-    tags = ['bronze_core']
+    tags = get_path_tags(model)
 ) }}
 
 {# Main query starts here #}

--- a/models/main_package/core/bronze/streamline/bronze__confirm_blocks.sql
+++ b/models/main_package/core/bronze/streamline/bronze__confirm_blocks.sql
@@ -4,7 +4,7 @@
 {# Set up dbt configuration #}
 {{ config (
     materialized = 'view',
-    tags = ['bronze_core']
+    tags = get_path_tags(model)
 ) }}
 
 {# Main query starts here #}

--- a/models/main_package/core/bronze/streamline/bronze__confirm_blocks_fr.sql
+++ b/models/main_package/core/bronze/streamline/bronze__confirm_blocks_fr.sql
@@ -4,7 +4,7 @@
 {# Set up dbt configuration #}
 {{ config (
     materialized = 'view',
-    tags = ['bronze_core']
+    tags = get_path_tags(model)
 ) }}
 
 {# Main query starts here #}

--- a/models/main_package/core/bronze/streamline/bronze__receipts.sql
+++ b/models/main_package/core/bronze/streamline/bronze__receipts.sql
@@ -4,7 +4,7 @@
 {# Set up dbt configuration #}
 {{ config (
     materialized = 'view',
-    tags = ['bronze_receipts']
+    tags = get_path_tags(model)
 ) }}
 
 {# Main query starts here #}

--- a/models/main_package/core/bronze/streamline/bronze__receipts_by_hash.sql
+++ b/models/main_package/core/bronze/streamline/bronze__receipts_by_hash.sql
@@ -7,7 +7,7 @@
 {# Set up dbt configuration #}
 {{ config (
     materialized = 'view',
-    tags = ['bronze_receipts_by_hash']
+    tags = get_path_tags(model)
 ) }}
 
 {# Main query starts here #}

--- a/models/main_package/core/bronze/streamline/bronze__receipts_by_hash_fr.sql
+++ b/models/main_package/core/bronze/streamline/bronze__receipts_by_hash_fr.sql
@@ -7,7 +7,7 @@
 {# Set up dbt configuration #}
 {{ config (
     materialized = 'view',
-    tags = ['bronze_receipts_by_hash']
+    tags = get_path_tags(model)
 ) }}
 
 {# Main query starts here #}

--- a/models/main_package/core/bronze/streamline/bronze__receipts_fr.sql
+++ b/models/main_package/core/bronze/streamline/bronze__receipts_fr.sql
@@ -4,7 +4,7 @@
 {# Set up dbt configuration #}
 {{ config (
     materialized = 'view',
-    tags = ['bronze_receipts']
+    tags = get_path_tags(model)
 ) }}
 
 {# Main query starts here #}

--- a/models/main_package/core/bronze/streamline/bronze__traces.sql
+++ b/models/main_package/core/bronze/streamline/bronze__traces.sql
@@ -4,7 +4,7 @@
 {# Set up dbt configuration #}
 {{ config (
     materialized = 'view',
-    tags = ['bronze_core']
+    tags = get_path_tags(model)
 ) }}
 
 {# Main query starts here #}

--- a/models/main_package/core/bronze/streamline/bronze__traces_fr.sql
+++ b/models/main_package/core/bronze/streamline/bronze__traces_fr.sql
@@ -4,7 +4,7 @@
 {# Set up dbt configuration #}
 {{ config (
     materialized = 'view',
-    tags = ['bronze_core']
+    tags = get_path_tags(model)
 ) }}
 
 {# Main query starts here #}

--- a/models/main_package/core/bronze/streamline/bronze__transactions.sql
+++ b/models/main_package/core/bronze/streamline/bronze__transactions.sql
@@ -4,7 +4,7 @@
 {# Set up dbt configuration #}
 {{ config (
     materialized = 'view',
-    tags = ['bronze_core']
+    tags = get_path_tags(model)
 ) }}
 
 {# Main query starts here #}

--- a/models/main_package/core/bronze/streamline/bronze__transactions_fr.sql
+++ b/models/main_package/core/bronze/streamline/bronze__transactions_fr.sql
@@ -4,7 +4,7 @@
 {# Set up dbt configuration #}
 {{ config (
     materialized = 'view',
-    tags = ['bronze_core']
+    tags = get_path_tags(model)
 ) }}
 
 {# Main query starts here #}

--- a/models/main_package/core/bronze/token_reads/bronze_api__token_reads.sql
+++ b/models/main_package/core/bronze/token_reads/bronze_api__token_reads.sql
@@ -8,7 +8,7 @@
     materialized = 'incremental',
     unique_key = "contract_address",
     full_refresh = vars.GLOBAL_BRONZE_FR_ENABLED,
-    tags = ['bronze_core', 'recent_test']
+    tags = get_path_tags(model)
 ) }}
 
 WITH base AS (

--- a/models/main_package/core/gold/core__dim_contracts.sql
+++ b/models/main_package/core/gold/core__dim_contracts.sql
@@ -6,7 +6,7 @@
     unique_key = 'address',
     merge_exclude_columns = ["inserted_timestamp"],
     post_hook = "ALTER TABLE {{ this }} ADD SEARCH OPTIMIZATION ON EQUALITY(address, symbol, name), SUBSTRING(address, symbol, name)",
-    tags = ['gold_core']
+    tags = get_path_tags(model)
 ) }}
 
 SELECT

--- a/models/main_package/core/gold/core__ez_native_transfers.sql
+++ b/models/main_package/core/gold/core__ez_native_transfers.sql
@@ -12,7 +12,7 @@
     incremental_predicates = [fsc_evm.standard_predicate()],
     full_refresh = vars.GLOBAL_GOLD_FR_ENABLED,
     post_hook = "ALTER TABLE {{ this }} ADD SEARCH OPTIMIZATION ON EQUALITY(origin_from_address, origin_to_address, from_address, to_address, origin_function_signature), SUBSTRING(origin_from_address, origin_to_address, from_address, to_address, origin_function_signature)",
-    tags = ['gold_core', 'ez_prices_model']
+    tags = get_path_tags(model)
 ) }}
 
 WITH base AS (

--- a/models/main_package/core/gold/core__ez_token_transfers.sql
+++ b/models/main_package/core/gold/core__ez_token_transfers.sql
@@ -12,7 +12,7 @@
     incremental_predicates = [fsc_evm.standard_predicate()],
     full_refresh = vars.GLOBAL_GOLD_FR_ENABLED,
     post_hook = "ALTER TABLE {{ this }} ADD SEARCH OPTIMIZATION ON EQUALITY(origin_from_address, origin_to_address, from_address, to_address, origin_function_signature), SUBSTRING(origin_from_address, origin_to_address, from_address, to_address, origin_function_signature)",
-    tags = ['gold_core', 'ez_prices_model']
+    tags = get_path_tags(model)
 ) }}
 
 WITH base AS (

--- a/models/main_package/core/gold/core__fact_blocks.sql
+++ b/models/main_package/core/gold/core__fact_blocks.sql
@@ -14,7 +14,7 @@
     cluster_by = ['block_timestamp::DATE'],
     incremental_predicates = [fsc_evm.standard_predicate()],
     full_refresh = vars.GLOBAL_GOLD_FR_ENABLED,
-    tags = ['gold_core', 'testing_tag']
+    tags = get_path_tags(model)
 ) }}
 
 SELECT

--- a/models/main_package/core/gold/core__fact_event_logs.sql
+++ b/models/main_package/core/gold/core__fact_event_logs.sql
@@ -11,7 +11,7 @@
     cluster_by = ['block_timestamp::DATE'],
     incremental_predicates = [fsc_evm.standard_predicate()],
     full_refresh = vars.GLOBAL_GOLD_FR_ENABLED,
-    tags = ['gold_core']
+    tags = get_path_tags(model)
 ) }}
 
 WITH base AS (

--- a/models/main_package/core/gold/core__fact_traces.sql
+++ b/models/main_package/core/gold/core__fact_traces.sql
@@ -11,7 +11,7 @@
     cluster_by = ['block_timestamp::DATE'],
     incremental_predicates = [fsc_evm.standard_predicate()],
     full_refresh = vars.GLOBAL_GOLD_FR_ENABLED,
-    tags = ['gold_core']
+    tags = get_path_tags(model)
 ) }}
 
 WITH silver_traces AS (

--- a/models/main_package/core/gold/core__fact_transactions.sql
+++ b/models/main_package/core/gold/core__fact_transactions.sql
@@ -14,7 +14,7 @@
     cluster_by = ['block_timestamp::DATE'],
     incremental_predicates = [fsc_evm.standard_predicate()],
     full_refresh = vars.GLOBAL_GOLD_FR_ENABLED,
-    tags = ['gold_core']
+    tags = get_path_tags(model)
 ) }}
 
 WITH base AS (

--- a/models/main_package/core/gold/tests/blocks/test_gold__fact_blocks_full.sql
+++ b/models/main_package/core/gold/tests/blocks/test_gold__fact_blocks_full.sql
@@ -3,7 +3,7 @@
 
 {{ config (
     materialized = "view",
-    tags = ['full_test']
+    tags = get_path_tags(model)
 ) }}
 
 SELECT

--- a/models/main_package/core/gold/tests/blocks/test_gold__fact_blocks_recent.sql
+++ b/models/main_package/core/gold/tests/blocks/test_gold__fact_blocks_recent.sql
@@ -3,7 +3,7 @@
 
 {{ config (
     materialized = "view",
-    tags = ['recent_test']
+    tags = get_path_tags(model)
 ) }}
 
 SELECT

--- a/models/main_package/core/gold/tests/event_logs/test_gold__fact_event_logs_full.sql
+++ b/models/main_package/core/gold/tests/event_logs/test_gold__fact_event_logs_full.sql
@@ -3,7 +3,7 @@
 
 {{ config (
     materialized = "view",
-    tags = ['full_test']
+    tags = get_path_tags(model)
 ) }}
 
 SELECT

--- a/models/main_package/core/gold/tests/event_logs/test_gold__fact_event_logs_recent.sql
+++ b/models/main_package/core/gold/tests/event_logs/test_gold__fact_event_logs_recent.sql
@@ -3,7 +3,7 @@
 
 {{ config (
     materialized = "view",
-    tags = ['recent_test']
+    tags = get_path_tags(model)
 ) }}
 
 SELECT

--- a/models/main_package/core/gold/tests/ez_native_transfers/test_gold__ez_native_transfers_full.sql
+++ b/models/main_package/core/gold/tests/ez_native_transfers/test_gold__ez_native_transfers_full.sql
@@ -3,7 +3,7 @@
 
 {{ config (
     materialized = "view",
-    tags = ['full_test', 'ez_prices_model']
+    tags = get_path_tags(model)
 ) }}
 
 SELECT

--- a/models/main_package/core/gold/tests/ez_native_transfers/test_gold__ez_native_transfers_recent.sql
+++ b/models/main_package/core/gold/tests/ez_native_transfers/test_gold__ez_native_transfers_recent.sql
@@ -3,7 +3,7 @@
 
 {{ config (
     materialized = "view",
-    tags = ['recent_test', 'ez_prices_model']
+    tags = get_path_tags(model)
 ) }}
 
 SELECT

--- a/models/main_package/core/gold/tests/ez_token_transfers/test_gold__ez_token_transfers_full.sql
+++ b/models/main_package/core/gold/tests/ez_token_transfers/test_gold__ez_token_transfers_full.sql
@@ -3,7 +3,7 @@
 
 {{ config (
     materialized = "view",
-    tags = ['full_test', 'ez_prices_model']
+    tags = get_path_tags(model)
 ) }}
 
 SELECT

--- a/models/main_package/core/gold/tests/ez_token_transfers/test_gold__ez_token_transfers_recent.sql
+++ b/models/main_package/core/gold/tests/ez_token_transfers/test_gold__ez_token_transfers_recent.sql
@@ -3,7 +3,7 @@
 
 {{ config (
     materialized = "view",
-    tags = ['recent_test', 'ez_prices_model']
+    tags = get_path_tags(model)
 ) }}
 
 SELECT

--- a/models/main_package/core/gold/tests/traces/test_gold__fact_traces_full.sql
+++ b/models/main_package/core/gold/tests/traces/test_gold__fact_traces_full.sql
@@ -3,7 +3,7 @@
 
 {{ config (
     materialized = "view",
-    tags = ['full_test']
+    tags = get_path_tags(model)
 ) }}
 
 SELECT

--- a/models/main_package/core/gold/tests/traces/test_gold__fact_traces_recent.sql
+++ b/models/main_package/core/gold/tests/traces/test_gold__fact_traces_recent.sql
@@ -3,7 +3,7 @@
 
 {{ config (
     materialized = "view",
-    tags = ['recent_test']
+    tags = get_path_tags(model)
 ) }}
 
 SELECT

--- a/models/main_package/core/gold/tests/transactions/test_gold__fact_transactions_full.sql
+++ b/models/main_package/core/gold/tests/transactions/test_gold__fact_transactions_full.sql
@@ -3,7 +3,7 @@
 
 {{ config (
     materialized = "view",
-    tags = ['full_test']
+    tags = get_path_tags(model)
 ) }}
 
 SELECT

--- a/models/main_package/core/gold/tests/transactions/test_gold__fact_transactions_recent.sql
+++ b/models/main_package/core/gold/tests/transactions/test_gold__fact_transactions_recent.sql
@@ -3,7 +3,7 @@
 
 {{ config (
     materialized = "view",
-    tags = ['recent_test']
+    tags = get_path_tags(model)
 ) }}
 
 SELECT

--- a/models/main_package/core/nft/nft__ez_nft_transfers.sql
+++ b/models/main_package/core/nft/nft__ez_nft_transfers.sql
@@ -12,7 +12,7 @@
     incremental_predicates = [fsc_evm.standard_predicate()],
     full_refresh = vars.GLOBAL_GOLD_FR_ENABLED,
     post_hook = "ALTER TABLE {{ this }} ADD SEARCH OPTIMIZATION ON EQUALITY(origin_from_address, origin_to_address, from_address, to_address, origin_function_signature), SUBSTRING(origin_from_address, origin_to_address, from_address, to_address, origin_function_signature)",
-    tags = ['nft_core']
+    tags = get_path_tags(model)
 ) }}
 
 WITH base AS (

--- a/models/main_package/core/nft/tests/test_nft__ez_nft_transfers_full.sql
+++ b/models/main_package/core/nft/tests/test_nft__ez_nft_transfers_full.sql
@@ -3,7 +3,7 @@
 
 {{ config (
     materialized = "view",
-    tags = ['full_test']
+    tags = get_path_tags(model)
 ) }}
 
 SELECT

--- a/models/main_package/core/nft/tests/test_nft__ez_nft_transfers_recent.sql
+++ b/models/main_package/core/nft/tests/test_nft__ez_nft_transfers_recent.sql
@@ -3,7 +3,7 @@
 
 {{ config (
     materialized = "view",
-    tags = ['recent_test']
+    tags = get_path_tags(model)
 ) }}
 
 SELECT

--- a/models/main_package/core/silver/silver__blocks.sql
+++ b/models/main_package/core/silver/silver__blocks.sql
@@ -14,7 +14,7 @@
     post_hook = "ALTER TABLE {{ this }} ADD SEARCH OPTIMIZATION on equality(block_number)",
     incremental_predicates = [fsc_evm.standard_predicate()],
     full_refresh = vars.GLOBAL_SILVER_FR_ENABLED,
-    tags = ['silver_core']
+    tags = get_path_tags(model)
 ) }}
 
 WITH bronze_blocks AS (

--- a/models/main_package/core/silver/silver__confirm_blocks.sql
+++ b/models/main_package/core/silver/silver__confirm_blocks.sql
@@ -14,7 +14,7 @@
     post_hook = "ALTER TABLE {{ this }} ADD SEARCH OPTIMIZATION on equality(block_number)",
     incremental_predicates = [fsc_evm.standard_predicate()],
     full_refresh = vars.GLOBAL_SILVER_FR_ENABLED,
-    tags = ['silver_confirm_blocks']
+    tags = get_path_tags(model)
 ) }}
 
 WITH bronze_confirm_blocks AS (

--- a/models/main_package/core/silver/silver__contracts.sql
+++ b/models/main_package/core/silver/silver__contracts.sql
@@ -5,7 +5,7 @@
     materialized = 'incremental',
     unique_key = 'contract_address',
     merge_exclude_columns = ["inserted_timestamp"],
-    tags = ['silver_core']
+    tags = get_path_tags(model)
 ) }}
 
 WITH base_metadata AS (

--- a/models/main_package/core/silver/silver__created_contracts.sql
+++ b/models/main_package/core/silver/silver__created_contracts.sql
@@ -6,7 +6,7 @@
     unique_key = "created_contract_address",
     merge_exclude_columns = ["inserted_timestamp"],
     post_hook = "ALTER TABLE {{ this }} ADD SEARCH OPTIMIZATION ON EQUALITY(block_timestamp, tx_hash, created_contract_address, creator_address), SUBSTRING(created_contract_address, creator_address)",
-    tags = ['silver_core']
+    tags = get_path_tags(model)
 ) }}
 
 SELECT

--- a/models/main_package/core/silver/silver__proxies.sql
+++ b/models/main_package/core/silver/silver__proxies.sql
@@ -6,7 +6,7 @@
     unique_key = ["contract_address", "implementation_contract"],
     cluster_by = ["start_timestamp::date"],
     post_hook = "ALTER TABLE {{ this }} ADD SEARCH OPTIMIZATION",
-    tags = ['silver_core']
+    tags = get_path_tags(model)
 ) }}
 
 WITH base AS (

--- a/models/main_package/core/silver/silver__receipts.sql
+++ b/models/main_package/core/silver/silver__receipts.sql
@@ -14,7 +14,7 @@
     post_hook = vars.MAIN_CORE_SILVER_RECEIPTS_POST_HOOK,
     incremental_predicates = [fsc_evm.standard_predicate()],
     full_refresh = vars.GLOBAL_SILVER_FR_ENABLED,
-    tags = ['silver_core']
+    tags = get_path_tags(model)
 ) }}
 
 WITH bronze_receipts AS (

--- a/models/main_package/core/silver/silver__relevant_contracts.sql
+++ b/models/main_package/core/silver/silver__relevant_contracts.sql
@@ -5,7 +5,7 @@
     materialized = 'incremental',
     unique_key = "contract_address",
     post_hook = "ALTER TABLE {{ this }} ADD SEARCH OPTIMIZATION on equality(contract_address)",
-    tags = ['silver_core']
+    tags = get_path_tags(model)
 ) }}
 
 WITH emitted_events AS (

--- a/models/main_package/core/silver/silver__traces.sql
+++ b/models/main_package/core/silver/silver__traces.sql
@@ -14,7 +14,7 @@
     post_hook = "ALTER TABLE {{ this }} ADD SEARCH OPTIMIZATION on equality(block_number)",
     incremental_predicates = [fsc_evm.standard_predicate()],
     full_refresh = vars.GLOBAL_SILVER_FR_ENABLED,
-    tags = ['silver_core']
+    tags = get_path_tags(model)
 ) }}
 
     WITH bronze_traces AS (

--- a/models/main_package/core/silver/silver__transactions.sql
+++ b/models/main_package/core/silver/silver__transactions.sql
@@ -14,7 +14,7 @@
     post_hook = "ALTER TABLE {{ this }} ADD SEARCH OPTIMIZATION on equality(block_number)",
     incremental_predicates = [fsc_evm.standard_predicate()],
     full_refresh = vars.GLOBAL_SILVER_FR_ENABLED,
-    tags = ['silver_core']
+    tags = get_path_tags(model)
 ) }}
 
 WITH bronze_transactions AS (

--- a/models/main_package/core/silver/tests/blocks/test_silver__blocks_full.sql
+++ b/models/main_package/core/silver/tests/blocks/test_silver__blocks_full.sql
@@ -3,7 +3,7 @@
 
 {{ config (
     materialized = "view",
-    tags = ['full_test']
+    tags = get_path_tags(model)
 ) }}
 
 SELECT

--- a/models/main_package/core/silver/tests/blocks/test_silver__blocks_recent.sql
+++ b/models/main_package/core/silver/tests/blocks/test_silver__blocks_recent.sql
@@ -3,7 +3,7 @@
 
 {{ config (
     materialized = "view",
-    tags = ['recent_test']
+    tags = get_path_tags(model)
 ) }}
 
 SELECT

--- a/models/main_package/core/silver/tests/confirm_blocks/test_silver__confirm_blocks_full.sql
+++ b/models/main_package/core/silver/tests/confirm_blocks/test_silver__confirm_blocks_full.sql
@@ -3,7 +3,7 @@
 
 {{ config (
     materialized = "view",
-    tags = ['full_test']
+    tags = get_path_tags(model)
 ) }}
 
 SELECT

--- a/models/main_package/core/silver/tests/confirm_blocks/test_silver__confirm_blocks_recent.sql
+++ b/models/main_package/core/silver/tests/confirm_blocks/test_silver__confirm_blocks_recent.sql
@@ -3,7 +3,7 @@
 
 {{ config (
     materialized = "view",
-    tags = ['recent_test_confirm_blocks']
+    tags = get_path_tags(model)
 ) }}
 
 {%- set default_hours = -24 * 5 -%}

--- a/models/main_package/core/silver/tests/contracts/test_silver__contracts_full.sql
+++ b/models/main_package/core/silver/tests/contracts/test_silver__contracts_full.sql
@@ -3,7 +3,7 @@
 
 {{ config (
     materialized = "view",
-    tags = ['full_test']
+    tags = get_path_tags(model)
 ) }}
 
 SELECT

--- a/models/main_package/core/silver/tests/contracts/test_silver__contracts_recent.sql
+++ b/models/main_package/core/silver/tests/contracts/test_silver__contracts_recent.sql
@@ -3,7 +3,7 @@
 
 {{ config (
     materialized = "view",
-    tags = ['daily_test']
+    tags = get_path_tags(model)
 ) }}
 
 SELECT

--- a/models/main_package/core/silver/tests/created_contracts/test_silver__created_contracts_full.sql
+++ b/models/main_package/core/silver/tests/created_contracts/test_silver__created_contracts_full.sql
@@ -3,7 +3,7 @@
 
 {{ config (
     materialized = "view",
-    tags = ['full_test']
+    tags = get_path_tags(model)
 ) }}
 
 SELECT

--- a/models/main_package/core/silver/tests/created_contracts/test_silver__created_contracts_recent.sql
+++ b/models/main_package/core/silver/tests/created_contracts/test_silver__created_contracts_recent.sql
@@ -3,7 +3,7 @@
 
 {{ config (
     materialized = "view",
-    tags = ['daily_test']
+    tags = get_path_tags(model)
 ) }}
 
 SELECT

--- a/models/main_package/core/silver/tests/proxies/test_silver__proxies_full.sql
+++ b/models/main_package/core/silver/tests/proxies/test_silver__proxies_full.sql
@@ -3,7 +3,7 @@
 
 {{ config (
     materialized = "view",
-    tags = ['full_test']
+    tags = get_path_tags(model)
 ) }}
 
 SELECT

--- a/models/main_package/core/silver/tests/proxies/test_silver__proxies_recent.sql
+++ b/models/main_package/core/silver/tests/proxies/test_silver__proxies_recent.sql
@@ -3,7 +3,7 @@
 
 {{ config (
     materialized = "view",
-    tags = ['daily_test']
+    tags = get_path_tags(model)
 ) }}
 
 SELECT

--- a/models/main_package/core/silver/tests/receipts/test_silver__receipts_full.sql
+++ b/models/main_package/core/silver/tests/receipts/test_silver__receipts_full.sql
@@ -3,7 +3,7 @@
 
 {{ config (
     materialized = "view",
-    tags = ['full_test']
+    tags = get_path_tags(model)
 ) }}
 
 SELECT

--- a/models/main_package/core/silver/tests/receipts/test_silver__receipts_recent.sql
+++ b/models/main_package/core/silver/tests/receipts/test_silver__receipts_recent.sql
@@ -3,7 +3,7 @@
 
 {{ config (
     materialized = "view",
-    tags = ['recent_test']
+    tags = get_path_tags(model)
 ) }}
 
 SELECT

--- a/models/main_package/core/silver/tests/traces/test_silver__traces_full.sql
+++ b/models/main_package/core/silver/tests/traces/test_silver__traces_full.sql
@@ -3,7 +3,7 @@
 
 {{ config (
     materialized = "view",
-    tags = ['full_test']
+    tags = get_path_tags(model)
 ) }}
 
 SELECT

--- a/models/main_package/core/silver/tests/traces/test_silver__traces_recent.sql
+++ b/models/main_package/core/silver/tests/traces/test_silver__traces_recent.sql
@@ -3,7 +3,7 @@
 
 {{ config (
     materialized = "view",
-    tags = ['recent_test']
+    tags = get_path_tags(model)
 ) }}
 
 SELECT

--- a/models/main_package/core/silver/tests/transactions/test_silver__transactions_full.sql
+++ b/models/main_package/core/silver/tests/transactions/test_silver__transactions_full.sql
@@ -3,7 +3,7 @@
 
 {{ config (
     materialized = "view",
-    tags = ['full_test']
+    tags = get_path_tags(model)
 ) }}
 
 SELECT

--- a/models/main_package/core/silver/tests/transactions/test_silver__transactions_recent.sql
+++ b/models/main_package/core/silver/tests/transactions/test_silver__transactions_recent.sql
@@ -3,7 +3,7 @@
 
 {{ config (
     materialized = "view",
-    tags = ['recent_test']
+    tags = get_path_tags(model)
 ) }}
 
 SELECT

--- a/models/main_package/core/streamline/complete/streamline__blocks_complete.sql
+++ b/models/main_package/core/streamline/complete/streamline__blocks_complete.sql
@@ -13,7 +13,7 @@
     cluster_by = "ROUND(block_number, -3)",
     post_hook = "ALTER TABLE {{ this }} ADD SEARCH OPTIMIZATION on equality(block_number)",
     full_refresh = vars.GLOBAL_STREAMLINE_FR_ENABLED,
-    tags = ['streamline_core_complete']
+    tags = get_path_tags(model)
 ) }}
 
 {# Main query starts here #}

--- a/models/main_package/core/streamline/complete/streamline__confirm_blocks_complete.sql
+++ b/models/main_package/core/streamline/complete/streamline__confirm_blocks_complete.sql
@@ -13,7 +13,7 @@
     cluster_by = "ROUND(block_number, -3)",
     post_hook = "ALTER TABLE {{ this }} ADD SEARCH OPTIMIZATION on equality(block_number)",
     full_refresh = vars.GLOBAL_STREAMLINE_FR_ENABLED,
-    tags = ['streamline_core_complete_confirm_blocks']
+    tags = get_path_tags(model)
 ) }}
 
 {# Main query starts here #}

--- a/models/main_package/core/streamline/complete/streamline__receipts_by_hash_complete.sql
+++ b/models/main_package/core/streamline/complete/streamline__receipts_by_hash_complete.sql
@@ -13,7 +13,7 @@
     cluster_by = "ROUND(block_number, -3)",
     post_hook = "ALTER TABLE {{ this }} ADD SEARCH OPTIMIZATION on equality(block_number, tx_hash)",
     full_refresh = vars.GLOBAL_STREAMLINE_FR_ENABLED,
-    tags = ['streamline_core_complete_receipts_by_hash']
+    tags = get_path_tags(model)
 ) }}
 
 {# Main query starts here #}

--- a/models/main_package/core/streamline/complete/streamline__receipts_complete.sql
+++ b/models/main_package/core/streamline/complete/streamline__receipts_complete.sql
@@ -13,7 +13,7 @@
     cluster_by = "ROUND(block_number, -3)",
     post_hook = "ALTER TABLE {{ this }} ADD SEARCH OPTIMIZATION on equality(block_number)",
     full_refresh = vars.GLOBAL_STREAMLINE_FR_ENABLED,
-    tags = ['streamline_core_complete_receipts']
+    tags = get_path_tags(model)
 ) }}
 
 {# Main query starts here #}

--- a/models/main_package/core/streamline/complete/streamline__traces_complete.sql
+++ b/models/main_package/core/streamline/complete/streamline__traces_complete.sql
@@ -13,7 +13,7 @@
     cluster_by = "ROUND(block_number, -3)",
     post_hook = "ALTER TABLE {{ this }} ADD SEARCH OPTIMIZATION on equality(block_number)",
     full_refresh = vars.GLOBAL_STREAMLINE_FR_ENABLED,
-    tags = ['streamline_core_complete']
+    tags = get_path_tags(model)
 ) }}
 
 {# Main query starts here #}

--- a/models/main_package/core/streamline/complete/streamline__transactions_complete.sql
+++ b/models/main_package/core/streamline/complete/streamline__transactions_complete.sql
@@ -13,7 +13,7 @@
     cluster_by = "ROUND(block_number, -3)",
     post_hook = "ALTER TABLE {{ this }} ADD SEARCH OPTIMIZATION on equality(block_number)",
     full_refresh = vars.GLOBAL_STREAMLINE_FR_ENABLED,
-    tags = ['streamline_core_complete']
+    tags = get_path_tags(model)
 ) }}
 
 {# Main query starts here #}

--- a/models/main_package/core/streamline/history/streamline__blocks_transactions_history.sql
+++ b/models/main_package/core/streamline/history/streamline__blocks_transactions_history.sql
@@ -20,7 +20,7 @@
             "exploded_key": tojson(['result', 'result.transactions'])
         }
     ),
-    tags = ['streamline_core_history']
+    tags = get_path_tags(model)
 ) }}
 
 {# Main query starts here #}

--- a/models/main_package/core/streamline/history/streamline__confirm_blocks_history.sql
+++ b/models/main_package/core/streamline/history/streamline__confirm_blocks_history.sql
@@ -19,7 +19,7 @@
             "sql_source": 'confirm_blocks_history'
         }
     ),
-    tags = ['streamline_core_history_confirm_blocks']
+    tags = get_path_tags(model)
 ) }}
 
 {# Main query starts here #}

--- a/models/main_package/core/streamline/history/streamline__receipts_by_hash_history.sql
+++ b/models/main_package/core/streamline/history/streamline__receipts_by_hash_history.sql
@@ -19,7 +19,7 @@
             "sql_source": 'receipts_by_hash_history'
         }
     ),
-    tags = ['streamline_core_history_receipts_by_hash']
+    tags = get_path_tags(model)
 ) }}
 
 

--- a/models/main_package/core/streamline/history/streamline__receipts_history.sql
+++ b/models/main_package/core/streamline/history/streamline__receipts_history.sql
@@ -20,7 +20,7 @@
             "exploded_key": tojson(['result'])
         }
     ),
-    tags = ['streamline_core_history_receipts']
+    tags = get_path_tags(model)
 ) }}
 
 {# Main query starts here #}

--- a/models/main_package/core/streamline/history/streamline__traces_history.sql
+++ b/models/main_package/core/streamline/history/streamline__traces_history.sql
@@ -20,7 +20,7 @@
             "exploded_key": tojson(['result'])
         }
     ),
-    tags = ['streamline_core_history']
+    tags = get_path_tags(model)
 ) }}
 
 {# Main query starts here #}

--- a/models/main_package/core/streamline/realtime/streamline__blocks_transactions_realtime.sql
+++ b/models/main_package/core/streamline/realtime/streamline__blocks_transactions_realtime.sql
@@ -20,7 +20,7 @@
             "exploded_key": tojson(['result', 'result.transactions'])
         }
     ),
-    tags = ['streamline_core_realtime']
+    tags = get_path_tags(model)
 ) }}
 
 {# Main query starts here #}

--- a/models/main_package/core/streamline/realtime/streamline__confirm_blocks_realtime.sql
+++ b/models/main_package/core/streamline/realtime/streamline__confirm_blocks_realtime.sql
@@ -19,7 +19,7 @@
             "sql_source": 'confirm_blocks_realtime'
         }
     ),
-    tags = ['streamline_core_realtime_confirm_blocks']
+    tags = get_path_tags(model)
 ) }}
 
 {# Main query starts here #}

--- a/models/main_package/core/streamline/realtime/streamline__receipts_by_hash_realtime.sql
+++ b/models/main_package/core/streamline/realtime/streamline__receipts_by_hash_realtime.sql
@@ -19,7 +19,7 @@
             "sql_source": 'receipts_by_hash_realtime'
         }
     ),
-    tags = ['streamline_core_realtime_receipts_by_hash']
+    tags = get_path_tags(model)
 ) }}
 
 {# Main query starts here #}

--- a/models/main_package/core/streamline/realtime/streamline__receipts_realtime.sql
+++ b/models/main_package/core/streamline/realtime/streamline__receipts_realtime.sql
@@ -20,7 +20,7 @@
             "exploded_key": tojson(['result'])
         }
     ),
-    tags = ['streamline_core_realtime_receipts']
+    tags = get_path_tags(model)
 ) }}
 
 {# Main query starts here #}

--- a/models/main_package/core/streamline/realtime/streamline__traces_realtime.sql
+++ b/models/main_package/core/streamline/realtime/streamline__traces_realtime.sql
@@ -20,7 +20,7 @@
             "exploded_key": tojson(['result'])
         }
     ),
-    tags = ['streamline_core_realtime']
+    tags = get_path_tags(model)
 ) }}
 
 {# Main query starts here #}

--- a/models/main_package/core/streamline/streamline__blocks.sql
+++ b/models/main_package/core/streamline/streamline__blocks.sql
@@ -6,7 +6,7 @@
 
 {{ config (
     materialized = "view",
-    tags = ['streamline_core_complete']
+    tags = get_path_tags(model)
 ) }}
 
 SELECT

--- a/models/main_package/core/streamline/streamline__get_chainhead.sql
+++ b/models/main_package/core/streamline/streamline__get_chainhead.sql
@@ -6,7 +6,7 @@
 
 {{ config (
     materialized = 'table',
-    tags = ['streamline_core_complete','chainhead']
+    tags = get_path_tags(model)
 ) }}
 
 SELECT

--- a/models/main_package/github_actions/github_actions__current_task_status.sql
+++ b/models/main_package/github_actions/github_actions__current_task_status.sql
@@ -3,7 +3,7 @@
 
 {{ config(
     materialized = 'view',
-    tags = ['gha_tasks']
+    tags = get_path_tags(model)
 ) }}
 
 {{ fsc_utils.gha_task_current_status_view() }}

--- a/models/main_package/github_actions/github_actions__task_history.sql
+++ b/models/main_package/github_actions/github_actions__task_history.sql
@@ -3,7 +3,7 @@
 
 {{ config(
     materialized = 'view',
-    tags = ['gha_tasks']
+    tags = get_path_tags(model)
 ) }}
 
 {{ fsc_utils.gha_task_history_view() }}

--- a/models/main_package/github_actions/github_actions__task_performance.sql
+++ b/models/main_package/github_actions/github_actions__task_performance.sql
@@ -3,7 +3,7 @@
 
 {{ config(
     materialized = 'view',
-    tags = ['gha_tasks']
+    tags = get_path_tags(model)
 ) }}
 
 {{ fsc_utils.gha_task_performance_view() }}

--- a/models/main_package/github_actions/github_actions__task_schedule.sql
+++ b/models/main_package/github_actions/github_actions__task_schedule.sql
@@ -3,7 +3,7 @@
 
 {{ config(
     materialized = 'view',
-    tags = ['gha_tasks']
+    tags = get_path_tags(model)
 ) }}
 
 {{ fsc_utils.gha_task_schedule_view() }}

--- a/models/main_package/github_actions/github_actions__tasks.sql
+++ b/models/main_package/github_actions/github_actions__tasks.sql
@@ -3,7 +3,7 @@
 
 {{ config(
     materialized = 'view',
-    tags = ['gha_tasks']
+    tags = get_path_tags(model)
 ) }}
 
 {{ fsc_utils.gha_tasks_view() }}

--- a/models/main_package/labels/bronze/bronze__labels.sql
+++ b/models/main_package/labels/bronze/bronze__labels.sql
@@ -6,7 +6,7 @@
 
 {{ config(
     materialized = 'view',
-    tags = ['bronze_labels']
+    tags = get_path_tags(model)
 ) }}
 
 SELECT

--- a/models/main_package/labels/gold/core__dim_labels.sql
+++ b/models/main_package/labels/gold/core__dim_labels.sql
@@ -8,7 +8,7 @@
     merge_exclude_columns = ["inserted_timestamp"],
     cluster_by = 'modified_timestamp::DATE',
     post_hook = "ALTER TABLE {{ this }} ADD SEARCH OPTIMIZATION ON EQUALITY(address, label_type, label_subtype, address_name, label), SUBSTRING(address, label_type, label_subtype, address_name, label); DELETE FROM {{ this }} WHERE address in (SELECT address FROM {{ ref('silver__labels') }} WHERE _is_deleted = TRUE);",
-    tags = ['gold_labels']
+    tags = get_path_tags(model)
 ) }}
 
 SELECT

--- a/models/main_package/labels/silver/silver__labels.sql
+++ b/models/main_package/labels/silver/silver__labels.sql
@@ -7,7 +7,7 @@
     incremental_strategy = 'merge',
     merge_exclude_columns = ["inserted_timestamp"],
     cluster_by = 'modified_timestamp::DATE',
-    tags = ['silver_labels']
+    tags = get_path_tags(model)
 ) }}
 
 SELECT

--- a/models/main_package/observability/observability__blocks.sql
+++ b/models/main_package/observability/observability__blocks.sql
@@ -8,7 +8,7 @@
     materialized = 'incremental',
     unique_key = 'test_timestamp',
     full_refresh = false,
-    tags = ['observability']
+    tags = get_path_tags(model)
 ) }}
 
 WITH lookback AS (

--- a/models/main_package/observability/observability__logs.sql
+++ b/models/main_package/observability/observability__logs.sql
@@ -8,7 +8,7 @@
     materialized = 'incremental',
     unique_key = 'test_timestamp',
     full_refresh = false,
-    tags = ['observability']
+    tags = get_path_tags(model)
 ) }}
 
 WITH lookback AS (

--- a/models/main_package/observability/observability__receipts.sql
+++ b/models/main_package/observability/observability__receipts.sql
@@ -8,7 +8,7 @@
     materialized = 'incremental',
     unique_key = 'test_timestamp',
     full_refresh = false,
-    tags = ['observability']
+    tags = get_path_tags(model)
 ) }}
 
 WITH lookback AS (

--- a/models/main_package/observability/observability__traces.sql
+++ b/models/main_package/observability/observability__traces.sql
@@ -8,7 +8,7 @@
     materialized = 'incremental',
     unique_key = 'test_timestamp',
     full_refresh = false,
-    tags = ['observability']
+    tags = get_path_tags(model)
 ) }}
 
 WITH lookback AS (

--- a/models/main_package/observability/observability__transactions.sql
+++ b/models/main_package/observability/observability__transactions.sql
@@ -8,7 +8,7 @@
     materialized = 'incremental',
     unique_key = 'test_timestamp',
     full_refresh = false,
-    tags = ['observability']
+    tags = get_path_tags(model)
 ) }}
 
 WITH lookback AS (

--- a/models/main_package/prices/bronze/bronze__complete_native_asset_metadata.sql
+++ b/models/main_package/prices/bronze/bronze__complete_native_asset_metadata.sql
@@ -7,7 +7,7 @@
 {# Set up dbt configuration #}
 {{ config (
     materialized = 'view',
-    tags = ['bronze_prices']
+    tags = get_path_tags(model)
 ) }}
 
 {# Main query starts here #}

--- a/models/main_package/prices/bronze/bronze__complete_native_prices.sql
+++ b/models/main_package/prices/bronze/bronze__complete_native_prices.sql
@@ -7,7 +7,7 @@
 {# Set up dbt configuration #}
 {{ config (
     materialized = 'view',
-    tags = ['bronze_prices']
+    tags = get_path_tags(model)
 ) }}
 
 {# Main query starts here #}

--- a/models/main_package/prices/bronze/bronze__complete_provider_asset_metadata.sql
+++ b/models/main_package/prices/bronze/bronze__complete_provider_asset_metadata.sql
@@ -7,7 +7,7 @@
 {# Set up dbt configuration #}
 {{ config (
     materialized = 'view',
-    tags = ['bronze_prices']
+    tags = get_path_tags(model)
 ) }}
 
 {# Main query starts here #}

--- a/models/main_package/prices/bronze/bronze__complete_provider_prices.sql
+++ b/models/main_package/prices/bronze/bronze__complete_provider_prices.sql
@@ -4,7 +4,7 @@
 {# Set up dbt configuration #}
 {{ config (
     materialized = 'view',
-    tags = ['bronze_prices']
+    tags = get_path_tags(model)
 ) }}
 
 {# Main query starts here #}

--- a/models/main_package/prices/bronze/bronze__complete_token_asset_metadata.sql
+++ b/models/main_package/prices/bronze/bronze__complete_token_asset_metadata.sql
@@ -7,7 +7,7 @@
 {# Set up dbt configuration #}
 {{ config (
     materialized = 'view',
-    tags = ['bronze_prices']
+    tags = get_path_tags(model)
 ) }}
 
 {# Main query starts here #}

--- a/models/main_package/prices/bronze/bronze__complete_token_prices.sql
+++ b/models/main_package/prices/bronze/bronze__complete_token_prices.sql
@@ -7,7 +7,7 @@
 {# Set up dbt configuration #}
 {{ config (
     materialized = 'view',
-    tags = ['bronze_prices']
+    tags = get_path_tags(model)
 ) }}
 
 {# Main query starts here #}

--- a/models/main_package/prices/gold/price__dim_asset_metadata.sql
+++ b/models/main_package/prices/gold/price__dim_asset_metadata.sql
@@ -7,7 +7,7 @@
     incremental_strategy = 'delete+insert',
     unique_key = 'dim_asset_metadata_id',
     post_hook = "ALTER TABLE {{ this }} ADD SEARCH OPTIMIZATION ON EQUALITY(asset_id, token_address, symbol, name),SUBSTRING(asset_id, token_address, symbol, name)",
-    tags = ['gold_prices']
+    tags = get_path_tags(model)
 ) }}
 
 {# Main query starts here #}

--- a/models/main_package/prices/gold/price__ez_asset_metadata.sql
+++ b/models/main_package/prices/gold/price__ez_asset_metadata.sql
@@ -7,7 +7,7 @@
     incremental_strategy = 'delete+insert',
     unique_key = 'ez_asset_metadata_id',
     post_hook = "ALTER TABLE {{ this }} ADD SEARCH OPTIMIZATION ON EQUALITY(asset_id, token_address, symbol, name),SUBSTRING(asset_id, token_address, symbol, name)",
-    tags = ['gold_prices']
+    tags = get_path_tags(model)
 ) }}
 
 {# Main query starts here #}

--- a/models/main_package/prices/gold/price__ez_prices_hourly.sql
+++ b/models/main_package/prices/gold/price__ez_prices_hourly.sql
@@ -8,7 +8,7 @@
     unique_key = 'ez_prices_hourly_id',
     cluster_by = ['hour::DATE'],
     post_hook = "ALTER TABLE {{ this }} ADD SEARCH OPTIMIZATION ON EQUALITY(token_address, symbol, name),SUBSTRING(token_address, symbol, name)",
-    tags = ['gold_prices']
+    tags = get_path_tags(model)
 ) }}
 
 {# Main query starts here #}

--- a/models/main_package/prices/gold/price__fact_prices_ohlc_hourly.sql
+++ b/models/main_package/prices/gold/price__fact_prices_ohlc_hourly.sql
@@ -8,7 +8,7 @@
     unique_key = 'fact_prices_ohlc_hourly_id',
     cluster_by = ['hour::DATE','provider'],
     post_hook = "ALTER TABLE {{ this }} ADD SEARCH OPTIMIZATION ON EQUALITY(asset_id),SUBSTRING(asset_id)",
-    tags = ['gold_prices']
+    tags = get_path_tags(model)
 ) }}
 
 {# Main query starts here #}

--- a/models/main_package/prices/silver/silver__complete_native_asset_metadata.sql
+++ b/models/main_package/prices/silver/silver__complete_native_asset_metadata.sql
@@ -6,7 +6,7 @@
     materialized = 'incremental',
     incremental_strategy = 'delete+insert',
     unique_key = 'complete_native_asset_metadata_id',
-    tags = ['silver_prices']
+    tags = get_path_tags(model)
 ) }}
 
 {# Main query starts here #}

--- a/models/main_package/prices/silver/silver__complete_native_prices.sql
+++ b/models/main_package/prices/silver/silver__complete_native_prices.sql
@@ -7,7 +7,7 @@
     incremental_strategy = 'delete+insert',
     unique_key = 'complete_native_prices_id',
     cluster_by = ['hour::DATE'],
-    tags = ['silver_prices']
+    tags = get_path_tags(model)
 ) }}
 
 {# Main query starts here #}

--- a/models/main_package/prices/silver/silver__complete_provider_asset_metadata.sql
+++ b/models/main_package/prices/silver/silver__complete_provider_asset_metadata.sql
@@ -6,7 +6,7 @@
     materialized = 'incremental',
     incremental_strategy = 'delete+insert',
     unique_key = 'complete_provider_asset_metadata_id',
-    tags = ['silver_prices']
+    tags = get_path_tags(model)
 ) }}
 
 {# Main query starts here #}

--- a/models/main_package/prices/silver/silver__complete_provider_prices.sql
+++ b/models/main_package/prices/silver/silver__complete_provider_prices.sql
@@ -7,7 +7,7 @@
     incremental_strategy = 'delete+insert',
     unique_key = 'complete_provider_prices_id',
     cluster_by = ['recorded_hour::DATE','provider'],
-    tags = ['silver_prices']
+    tags = get_path_tags(model)
 ) }}
 
 {# Main query starts here #}

--- a/models/main_package/prices/silver/silver__complete_token_asset_metadata.sql
+++ b/models/main_package/prices/silver/silver__complete_token_asset_metadata.sql
@@ -6,7 +6,7 @@
     materialized = 'incremental',
     incremental_strategy = 'delete+insert',
     unique_key = 'complete_token_asset_metadata_id',
-    tags = ['silver_prices']
+    tags = get_path_tags(model)
 ) }}
 
 {# Main query starts here #}

--- a/models/main_package/prices/silver/silver__complete_token_prices.sql
+++ b/models/main_package/prices/silver/silver__complete_token_prices.sql
@@ -7,7 +7,7 @@
     incremental_strategy = 'delete+insert',
     unique_key = 'complete_token_prices_id',
     cluster_by = ['hour::DATE'],
-    tags = ['silver_prices']
+    tags = get_path_tags(model)
 ) }}
 
 {# Main query starts here #}

--- a/models/main_package/utils/utils__number_sequence.sql
+++ b/models/main_package/utils/utils__number_sequence.sql
@@ -9,7 +9,7 @@
     cluster_by = 'round(_id,-3)',
     post_hook = "ALTER TABLE {{ this }} ADD SEARCH OPTIMIZATION on equality(_id)",
     full_refresh = false,
-    tags = ['utils']
+    tags = get_path_tags(model)
 ) }}
 
 SELECT

--- a/models/main_package/variables/admin__dim_variables.sql
+++ b/models/main_package/variables/admin__dim_variables.sql
@@ -3,7 +3,7 @@
 
 {{ config(
     materialized = 'view',
-    tags = ['admin_vars']
+    tags = get_path_tags(model)
 ) }}
 
 SELECT

--- a/models/main_package/variables/admin__ez_variables.sql
+++ b/models/main_package/variables/admin__ez_variables.sql
@@ -3,7 +3,7 @@
 
 {{ config(
     materialized = 'view',
-    tags = ['admin_vars']
+    tags = get_path_tags(model)
 ) }}
 
 SELECT

--- a/models/main_package/variables/admin__fact_rpc_details.sql
+++ b/models/main_package/variables/admin__fact_rpc_details.sql
@@ -6,7 +6,7 @@
 
 {{ config(
     materialized = 'table',
-    tags = ['rpc_settings']
+    tags = get_path_tags(model)
 ) }}
 
 select 

--- a/models/main_package/variables/admin__fact_variables.sql
+++ b/models/main_package/variables/admin__fact_variables.sql
@@ -3,7 +3,7 @@
 
 {{ config(
     materialized = 'view',
-    tags = ['admin_vars']
+    tags = get_path_tags(model)
 ) }}
 
 {%- set vars_data = vars_config(all_projects=true) -%}

--- a/models/scores_package/scores__actions.sql
+++ b/models/scores_package/scores__actions.sql
@@ -12,7 +12,7 @@
     incremental_strategy = "delete+insert",
     cluster_by = "block_date",
     full_refresh = false,
-    tags = ['scores']
+    tags = get_path_tags(model)
 ) }}
 
 {% if is_incremental() %}

--- a/models/scores_package/scores__actions_agg.sql
+++ b/models/scores_package/scores__actions_agg.sql
@@ -15,7 +15,7 @@
     cluster_by = "score_date",
     version = 1,
     full_refresh = false,
-    tags = ['scores']
+    tags = get_path_tags(model)
 ) }}
 
     {% set score_dates_query %}

--- a/models/scores_package/scores__actions_daily.sql
+++ b/models/scores_package/scores__actions_daily.sql
@@ -10,7 +10,7 @@
     incremental_strategy = "delete+insert",
     cluster_by = "block_date",
     version = 1,
-    tags = ['scores']
+    tags = get_path_tags(model)
 ) }}
 
     {% if is_incremental() %}

--- a/models/scores_package/scores__dates.sql
+++ b/models/scores_package/scores__dates.sql
@@ -3,7 +3,7 @@
 
 {{ config (
     materialized = "view",
-    tags = ['scores']
+    tags = get_path_tags(model)
 ) }}
 
 select * from {{ source('data_science_silver', 'dates') }}

--- a/models/scores_package/scores__event_sigs.sql
+++ b/models/scores_package/scores__event_sigs.sql
@@ -3,7 +3,7 @@
 
 {{ config (
     materialized = "view",
-    tags = ['scores']
+    tags = get_path_tags(model)
 ) }}
 
 select * from {{ source('data_science_silver', 'evm_event_sigs') }}

--- a/models/scores_package/scores__known_event_names.sql
+++ b/models/scores_package/scores__known_event_names.sql
@@ -3,7 +3,7 @@
 
 {{ config (
     materialized = "view",
-    tags = ['scores']
+    tags = get_path_tags(model)
 ) }}
 
 select * from {{ source('data_science_silver', 'evm_known_event_names') }}

--- a/models/scores_package/scores__known_event_sigs.sql
+++ b/models/scores_package/scores__known_event_sigs.sql
@@ -3,7 +3,7 @@
 
 {{ config (
     materialized = "view",
-    tags = ['scores']
+    tags = get_path_tags(model)
 ) }}
 
 select * from {{ source('data_science_silver', 'evm_known_event_sigs') }}

--- a/models/scores_package/scores__scoring_activity_categories.sql
+++ b/models/scores_package/scores__scoring_activity_categories.sql
@@ -3,7 +3,7 @@
 
 {{ config (
     materialized = "view",
-    tags = ['scores']
+    tags = get_path_tags(model)
 ) }}
 
 select * from {{ source('data_science_silver', 'scoring_activity_categories') }}

--- a/models/scores_package/scores__target_days.sql
+++ b/models/scores_package/scores__target_days.sql
@@ -6,7 +6,7 @@
 
 {{ config (
     materialized = "view",
-    tags = ['scores']
+    tags = get_path_tags(model)
 ) }}
 
 {% if execute %}

--- a/models/scores_package/scores__wrapped_assets.sql
+++ b/models/scores_package/scores__wrapped_assets.sql
@@ -3,7 +3,7 @@
 
 {{ config (
     materialized = "view",
-    tags = ['scores']
+    tags = get_path_tags(model)
 ) }}
 
 select * from {{ source('data_science_silver', 'evm_wrapped_assets') }}

--- a/selectors.yml
+++ b/selectors.yml
@@ -1,4 +1,75 @@
 selectors:
+
+  - name: chainhead_models
+    description: "Standard chainhead models"
+    definition:
+      union:
+        - intersection:
+            - tag:streamline
+            - tag:complete
+            - exclude:
+                - tag:streamline__receipts_by_hash_complete
+                - tag:streamline__confirm_blocks_complete
+        - intersection:
+            - tag:streamline
+            - tag:realtime
+            - exclude:
+                - tag:streamline__receipts_by_hash_realtime
+                - tag:streamline__confirm_blocks_realtime
+
+  - name: main
+    description: "Main GHA scheduled run"
+    definition:
+      method: tag
+      value: main_package
+      exclude:
+        - tag:streamline
+        - tag:github_actions
+        - tag:tests
+        - intersection:
+            - tag:prices
+            - tag:bronze
+        - tag:observability
+
+  - name: send_logs
+    description: "Streamline decoded logs run"
+    definition:
+      union:
+        - intersection:
+            - tag:decoded_logs
+            - tag:streamline
+        - tag:bronze__decoded_logs
+
+  - name: decoded_logs
+    description: "Update silver and Gold tables with latest decoded logs"
+    definition:
+      union:
+        - tag:decoded_logs
+        - exclude:
+          - tag:streamline
+          - tag:tests
+
+  - name: get_abis
+    description: "ABI models"
+    definition:
+      union:
+        - tag:bronze__contract_abis
+        - tag:bronze__contract_abis_fr
+        - intersection:
+            - tag:abis
+            - tag:streamline
+
+  - name: abis
+    description: "Update abis models"
+    definition:
+      intersection:
+        - tag:decoder_package
+        - tag:abis
+        - exclude:
+            - tag:streamline
+            - tag:bronze
+            - tag:tests
+
   - name: recent_tests
     description: "All recent tests"
     definition:
@@ -33,36 +104,3 @@ selectors:
         - test_type: singular
         - exclude:
             - test_name:*recent*
-
-  - name: main
-    description: "Main GHA scheduled run"
-    definition:
-      method: tag
-      value: main_package
-      exclude:
-        - tag:streamline
-        - tag:github_actions
-        - tag:tests
-        - intersection:
-            - tag:prices
-            - tag:bronze
-        - tag:observability
-
-  - name: send_logs
-    description: "Streamline decoded logs run"
-    definition:
-      union:
-        - intersection:
-            - tag:decoded_logs
-            - tag:streamline
-        - tag:bronze__decoded_logs
-
-  - name: get_abis
-    description: "ABI models"
-    definition:
-      union:
-        - tag:bronze__contract_abis
-        - tag:bronze__contract_abis_fr
-        - intersection:
-            - tag:abis
-            - tag:streamline

--- a/selectors.yml
+++ b/selectors.yml
@@ -1,0 +1,68 @@
+selectors:
+  - name: recent_tests
+    description: "All recent tests"
+    definition:
+      test_name:*recent*
+
+  - name: unique_tests
+    description: "All unique tests"
+    definition:
+      test_name:*unique*
+
+  - name: null_tests
+    description: "All null tests"
+    definition:
+      test_name:*null*
+
+  - name: other_tests
+    description: "Tests that don't match recent, unique, or null patterns"
+    definition:
+      union:
+        - test_type: generic
+        - test_type: singular
+        - exclude:
+            - test_name:*recent*
+            - test_name:*unique*
+            - test_name:*null*
+  
+  - name: non_recent_tests
+    description: "Tests that don't match recent patterns"
+    definition:
+      union:
+        - test_type: generic
+        - test_type: singular
+        - exclude:
+            - test_name:*recent*
+
+  - name: main
+    description: "Main GHA scheduled run"
+    definition:
+      method: tag
+      value: main_package
+      exclude:
+        - tag:streamline
+        - tag:github_actions
+        - tag:tests
+        - intersection:
+            - tag:prices
+            - tag:bronze
+        - tag:observability
+
+  - name: send_logs
+    description: "Streamline decoded logs run"
+    definition:
+      union:
+        - intersection:
+            - tag:decoded_logs
+            - tag:streamline
+        - tag:bronze__decoded_logs
+
+  - name: get_abis
+    description: "ABI models"
+    definition:
+      union:
+        - tag:bronze__contract_abis
+        - tag:bronze__contract_abis_fr
+        - intersection:
+            - tag:abis
+            - tag:streamline


### PR DESCRIPTION
1. Adds automated tag generation macro based on file path
   - Replaces all tag configs with macro ref `tags = get_path_tags(model)`
   - `fsc_evm/models/main_package/labels/bronze/bronze__labels.sql`will be auto-tagged with:
``` 
"tags": [
    "main_package",
    "labels",
    "bronze",
    "bronze__labels"
  ] 
```
3. Adds `tag_mapping` macro
   - Here you can add tags to tags, ie `reorg` can be added to all `defi` folder tags or `bronze__labels` can have a `phase_2` tag applied
   - Less important now that we have selectors built out
2. Adds `selectors.yml` for run commands
   - Main run command will now be`dbt run --selector main`
   - All command logic is stored within the `selectors.yml`
   - In order to run `selectors.yml` needs to be in root directory. Added two make commands to account for this:
      - `make copy_selectors`: this command will copy the `selectors.yml` from fsc_evm package into the root repo directory
      - `make append_selectors`: this command will append the root directories selector doc to the fsc_evm doc under the root directory. Giving us the ability to add repo specific selectors
   - Need to add `include dbt_packages/fsc_evm/makefile` to top of repo make files