### PR TITLE
Fix/missing-r-var

### DIFF
--- a/models/main_package/core/gold/core__fact_event_logs.sql
+++ b/models/main_package/core/gold/core__fact_event_logs.sql
@@ -18,7 +18,7 @@ WITH base AS (
 
     SELECT
         block_number,
-        {% if uses_receipts_by_hash %}
+        {% if vars.MAIN_CORE_RECEIPTS_BY_HASH_ENABLED %}
             tx_hash,
         {% else %}
             receipts_json :transactionHash :: STRING AS tx_hash,


### PR DESCRIPTION
1. Missing receipts_by_hash var
2. Requires new version tag `git tag -a v4.0.0-beta.7.1 -m "version 4.0.0-beta.7.1"`