### PR TITLE
AN-5800/env-vars

### DIFF
--- a/.github/workflows/dbt_run_template.yml
+++ b/.github/workflows/dbt_run_template.yml
@@ -7,10 +7,10 @@ on:
         required: false
         type: string
         default: DBT_CLOUD
-      environment:
+      target:
         required: false
         type: string
-        default: workflow_prod
+        default: prod
       command_name:
         required: true
         type: string
@@ -31,7 +31,7 @@ jobs:
   run_dbt_jobs:
     runs-on: ubuntu-latest
     environment:
-      name: ${{ inputs.environment }}
+      name: workflow_secrets
 
     steps:
       - uses: actions/checkout@v3
@@ -54,11 +54,11 @@ jobs:
           echo "USER=DBT_CLOUD_$PROFILE_NAME" >> $GITHUB_ENV  
           echo "PASSWORD=${{ secrets.PASSWORD }}" >> $GITHUB_ENV
           
-          if [[ "${{ inputs.environment }}" == *"prod"* ]]; then
+          if [[ "${{ inputs.target }}" == *"prod"* ]]; then
             echo "DATABASE=$PROFILE_NAME" >> $GITHUB_ENV
             echo "ROLE=DBT_CLOUD_$PROFILE_NAME" >> $GITHUB_ENV
             echo "WAREHOUSE=DBT_CLOUD" >> $GITHUB_ENV
-          elif [[ "${{ inputs.environment }}" == *"test"* ]]; then
+          elif [[ "${{ inputs.target }}" == *"test"* ]]; then
             echo "DATABASE=$PROFILE_NAME" >> $GITHUB_ENV
             echo "ROLE=DBT_CLOUD_$PROFILE_NAME" >> $GITHUB_ENV
             echo "WAREHOUSE=DBT_TEST" >> $GITHUB_ENV

--- a/.github/workflows/dbt_run_template.yml
+++ b/.github/workflows/dbt_run_template.yml
@@ -1,0 +1,88 @@
+name: dbt_run_template
+
+on:
+  workflow_call:
+    inputs:
+      warehouse:
+        required: false
+        type: string
+        default: DBT_CLOUD
+      environment:
+        required: false
+        type: string
+        default: workflow_prod
+      command_name:
+          required: true
+          type: string
+          default: Run DBT Command
+      command:
+          required: true
+          type: string
+      command_name_2:
+          required: false
+          type: string
+          default: Run DBT Command 2 (if enabled)
+      command_2:
+          required: false
+          type: string
+          default: ""
+          
+jobs:
+  run_dbt_jobs:
+    runs-on: ubuntu-latest
+    environment:
+      name: ${{ inputs.environment }}
+
+    steps:
+      - uses: actions/checkout@v3
+      
+      - name: Extract project & profile names from dbt_project.yml
+        id: project-name
+        run: |
+          PROFILE_NAME=$(grep "^profile:" dbt_project.yml | sed 's/^profile:[[:space:]]*"//' | sed 's/".*$//')
+          PROJECT_NAME=$(grep "^name:" dbt_project.yml | sed 's/^name:[[:space:]]*"//' | sed 's/".*$//')
+          echo "PROFILE_NAME=$PROFILE_NAME" >> $GITHUB_ENV
+          echo "PROJECT_NAME=$PROJECT_NAME" >> $GITHUB_ENV
+          echo "PROFILE_NAME: $PROFILE_NAME"
+          echo "PROJECT_NAME: $PROJECT_NAME"
+      
+      - name: Set environment variables
+        run: |
+          echo "ACCOUNT=vna27887.us-east-1" >> $GITHUB_ENV
+          echo "REGION=us-east-1" >> $GITHUB_ENV
+          echo "SCHEMA=ADMIN" >> $GITHUB_ENV
+          echo "USER=DBT_CLOUD_$PROFILE_NAME" >> $GITHUB_ENV  
+          echo "PASSWORD=${{ secrets.PASSWORD }}" >> $GITHUB_ENV
+          
+          if [[ "${{ inputs.environment }}" == *"prod"* ]]; then
+            echo "DATABASE=$PROFILE_NAME" >> $GITHUB_ENV
+            echo "ROLE=DBT_CLOUD_$PROFILE_NAME" >> $GITHUB_ENV
+            echo "WAREHOUSE=DBT_CLOUD" >> $GITHUB_ENV
+          elif [[ "${{ inputs.environment }}" == *"test"* ]]; then
+            echo "DATABASE=$PROFILE_NAME" >> $GITHUB_ENV
+            echo "ROLE=DBT_CLOUD_$PROFILE_NAME" >> $GITHUB_ENV
+            echo "WAREHOUSE=DBT_TEST" >> $GITHUB_ENV
+          else
+            echo "DATABASE=${PROFILE_NAME}_DEV" >> $GITHUB_ENV
+            echo "ROLE=INTERNAL_DEV" >> $GITHUB_ENV
+            echo "WAREHOUSE=${{ inputs.warehouse }}" >> $GITHUB_ENV
+          fi
+          
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
+          cache: "pip"
+
+      - name: Install dependencies
+        run: |
+          pip install -r requirements.txt
+          dbt deps
+      
+      - name: ${{inputs.command_name}}
+        run: |
+          ${{ inputs.command }}
+
+      - name: ${{inputs.command_name_2}}
+        if: "${{ inputs.command_2 != '' }}"
+        run: |
+          ${{ inputs.command_2 }}

--- a/.github/workflows/dbt_run_template.yml
+++ b/.github/workflows/dbt_run_template.yml
@@ -48,6 +48,7 @@ jobs:
       
       - name: Set environment variables
         run: |
+          echo "TARGET=${{ inputs.target }}" >> $GITHUB_ENV
           echo "ACCOUNT=vna27887.us-east-1" >> $GITHUB_ENV
           echo "REGION=us-east-1" >> $GITHUB_ENV
           echo "SCHEMA=ADMIN" >> $GITHUB_ENV

--- a/.github/workflows/dbt_run_template_alter_all_gha_tasks.yml
+++ b/.github/workflows/dbt_run_template_alter_all_gha_tasks.yml
@@ -7,10 +7,10 @@ on:
         type: choice
         description: 'Action to perform on all tasks'
         required: true
-        default: 'RESUME'
+        default: RESUME
         options:
-          - 'RESUME'
-          - 'SUSPEND'
+          - RESUME
+          - SUSPEND
       target:
         type: string
         required: false

--- a/.github/workflows/dbt_run_template_alter_all_gha_tasks.yml
+++ b/.github/workflows/dbt_run_template_alter_all_gha_tasks.yml
@@ -1,0 +1,73 @@
+name: dbt_run_template_alter_all_gha_tasks
+
+on:
+  workflow_dispatch:
+    inputs:
+      task_action:
+        type: choice
+        description: 'Action to perform on all tasks'
+        required: true
+        default: 'RESUME'
+        options:
+          - 'RESUME'
+          - 'SUSPEND'
+      target:
+        type: string
+        required: false
+        default: prod
+
+jobs:
+  run_dbt_jobs:
+    runs-on: ubuntu-latest
+    environment:
+      name: workflow_secrets
+
+    steps:
+      - uses: actions/checkout@v3
+      
+      - name: Extract project & profile names from dbt_project.yml
+        id: project-name
+        run: |
+          PROFILE_NAME=$(grep "^profile:" dbt_project.yml | sed 's/^profile:[[:space:]]*"//' | sed 's/".*$//')
+          PROJECT_NAME=$(grep "^name:" dbt_project.yml | sed 's/^name:[[:space:]]*"//' | sed 's/".*$//')
+          echo "PROFILE_NAME=$PROFILE_NAME" >> $GITHUB_ENV
+          echo "PROJECT_NAME=$PROJECT_NAME" >> $GITHUB_ENV
+          echo "PROFILE_NAME: $PROFILE_NAME"
+          echo "PROJECT_NAME: $PROJECT_NAME"
+      
+      - name: Set environment variables
+        run: |
+          echo "TARGET=${{ inputs.target }}" >> $GITHUB_ENV
+          echo "ACCOUNT=vna27887.us-east-1" >> $GITHUB_ENV
+          echo "REGION=us-east-1" >> $GITHUB_ENV
+          echo "SCHEMA=ADMIN" >> $GITHUB_ENV
+          echo "USER=DBT_CLOUD_$PROFILE_NAME" >> $GITHUB_ENV  
+          echo "PASSWORD=${{ secrets.PASSWORD }}" >> $GITHUB_ENV
+          
+          if [[ "${{ inputs.target }}" == *"prod"* ]]; then
+            echo "DATABASE=$PROFILE_NAME" >> $GITHUB_ENV
+            echo "ROLE=DBT_CLOUD_$PROFILE_NAME" >> $GITHUB_ENV
+            echo "WAREHOUSE=DBT_CLOUD" >> $GITHUB_ENV
+          elif [[ "${{ inputs.target }}" == *"test"* ]]; then
+            echo "DATABASE=$PROFILE_NAME" >> $GITHUB_ENV
+            echo "ROLE=DBT_CLOUD_$PROFILE_NAME" >> $GITHUB_ENV
+            echo "WAREHOUSE=DBT_TEST" >> $GITHUB_ENV
+          else
+            echo "DATABASE=${PROFILE_NAME}_DEV" >> $GITHUB_ENV
+            echo "ROLE=INTERNAL_DEV" >> $GITHUB_ENV
+            echo "WAREHOUSE=DBT_CLOUD" >> $GITHUB_ENV
+          fi
+          
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
+          cache: "pip"
+
+      - name: Install dependencies
+        run: |
+          pip install -r requirements.txt
+          dbt deps
+
+      - name: Run DBT Jobs
+        run: |
+          dbt run-operation alter_all_gha_tasks --args '{"task_action": "${{ inputs.task_action }}"}' 

--- a/.github/workflows/dbt_run_template_alter_gha_task.yml
+++ b/.github/workflows/dbt_run_template_alter_gha_task.yml
@@ -1,4 +1,4 @@
-name: dbt_alter_gha_tasks
+name: dbt_run_template_alter_gha_task
 
 on:
   workflow_call:
@@ -38,6 +38,7 @@ jobs:
       
       - name: Set environment variables
         run: |
+          echo "TARGET=${{ inputs.target }}" >> $GITHUB_ENV
           echo "ACCOUNT=vna27887.us-east-1" >> $GITHUB_ENV
           echo "REGION=us-east-1" >> $GITHUB_ENV
           echo "SCHEMA=ADMIN" >> $GITHUB_ENV

--- a/.github/workflows/dbt_run_template_alter_gha_task.yml
+++ b/.github/workflows/dbt_run_template_alter_gha_task.yml
@@ -1,32 +1,21 @@
-name: dbt_run_template
+name: dbt_alter_gha_tasks
 
 on:
   workflow_call:
     inputs:
-      warehouse:
-        required: false
+      workflow_name:
         type: string
-        default: DBT_CLOUD
+        description: 'Name of the workflow to perform the action on, no .yml extension'
+        required: true
+      task_action:
+        type: string
+        description: 'Action to perform'
+        required: true
       environment:
-        required: false
         type: string
-        default: workflow_prod
-      command_name:
+        description: 'Environment to run the workflow in'
         required: true
-        type: string
-        default: Run DBT Command
-      command:
-        required: true
-        type: string
-      command_name_2:
-        required: false
-        type: string
-        default: Run DBT Command 2 (if enabled)
-      command_2:
-        required: false
-        type: string
-        default: ""
-          
+
 jobs:
   run_dbt_jobs:
     runs-on: ubuntu-latest
@@ -65,7 +54,7 @@ jobs:
           else
             echo "DATABASE=${PROFILE_NAME}_DEV" >> $GITHUB_ENV
             echo "ROLE=INTERNAL_DEV" >> $GITHUB_ENV
-            echo "WAREHOUSE=${{ inputs.warehouse }}" >> $GITHUB_ENV
+            echo "WAREHOUSE=DBT_CLOUD" >> $GITHUB_ENV
           fi
           
       - uses: actions/setup-python@v4
@@ -77,12 +66,10 @@ jobs:
         run: |
           pip install -r requirements.txt
           dbt deps
-      
-      - name: ${{inputs.command_name}}
-        run: |
-          ${{ inputs.command }}
 
-      - name: ${{inputs.command_name_2}}
-        if: "${{ inputs.command_2 != '' }}"
+      - name: Set up workflow name
+        run: echo "WORKFLOW_NAME_UPPER=$(echo '${{ inputs.workflow_name }}' | tr '[:lower:]' '[:upper:]')" >> $GITHUB_ENV
+
+      - name: Run DBT Jobs
         run: |
-          ${{ inputs.command_2 }}
+          dbt run-operation fsc_utils.alter_gha_task --args '{ "task_name": "TRIGGER_${{ env.WORKFLOW_NAME_UPPER }}", "task_action": "${{ inputs.task_action }}" }'

--- a/.github/workflows/dbt_run_template_alter_gha_task.yml
+++ b/.github/workflows/dbt_run_template_alter_gha_task.yml
@@ -11,16 +11,17 @@ on:
         type: string
         description: 'Action to perform'
         required: true
-      environment:
+      target:
         type: string
-        description: 'Environment to run the workflow in'
-        required: true
+        description: 'Target environment to run the workflow in'
+        required: false
+        default: prod
 
 jobs:
   run_dbt_jobs:
     runs-on: ubuntu-latest
     environment:
-      name: ${{ inputs.environment }}
+      name: workflow_secrets
 
     steps:
       - uses: actions/checkout@v3
@@ -43,11 +44,11 @@ jobs:
           echo "USER=DBT_CLOUD_$PROFILE_NAME" >> $GITHUB_ENV  
           echo "PASSWORD=${{ secrets.PASSWORD }}" >> $GITHUB_ENV
           
-          if [[ "${{ inputs.environment }}" == *"prod"* ]]; then
+          if [[ "${{ inputs.target }}" == *"prod"* ]]; then
             echo "DATABASE=$PROFILE_NAME" >> $GITHUB_ENV
             echo "ROLE=DBT_CLOUD_$PROFILE_NAME" >> $GITHUB_ENV
             echo "WAREHOUSE=DBT_CLOUD" >> $GITHUB_ENV
-          elif [[ "${{ inputs.environment }}" == *"test"* ]]; then
+          elif [[ "${{ inputs.target }}" == *"test"* ]]; then
             echo "DATABASE=$PROFILE_NAME" >> $GITHUB_ENV
             echo "ROLE=DBT_CLOUD_$PROFILE_NAME" >> $GITHUB_ENV
             echo "WAREHOUSE=DBT_TEST" >> $GITHUB_ENV

--- a/.github/workflows/dbt_run_template_alter_gha_task.yml
+++ b/.github/workflows/dbt_run_template_alter_gha_task.yml
@@ -73,4 +73,4 @@ jobs:
 
       - name: Run DBT Jobs
         run: |
-          dbt run-operation fsc_utils.alter_gha_task --args '{ "task_name": "TRIGGER_${{ env.WORKFLOW_NAME_UPPER }}", "task_action": "${{ inputs.task_action }}" }'
+          dbt run-operation alter_gha_task --args '{ "task_names": "TRIGGER_${{ env.WORKFLOW_NAME_UPPER }}", "task_action": "${{ inputs.task_action }}" }'

--- a/.github/workflows/dbt_run_template_alter_gha_task.yml
+++ b/.github/workflows/dbt_run_template_alter_gha_task.yml
@@ -13,7 +13,6 @@ on:
         required: true
       target:
         type: string
-        description: 'Target environment to run the workflow in'
         required: false
         default: prod
 

--- a/.github/workflows/dbt_run_template_dev_refresh.yml
+++ b/.github/workflows/dbt_run_template_dev_refresh.yml
@@ -24,6 +24,7 @@ jobs:
       
       - name: Set production environment variables
         run: |
+          echo "TARGET=prod" >> $GITHUB_ENV
           echo "ACCOUNT=vna27887.us-east-1" >> $GITHUB_ENV
           echo "REGION=us-east-1" >> $GITHUB_ENV
           echo "SCHEMA=ADMIN" >> $GITHUB_ENV
@@ -68,6 +69,7 @@ jobs:
       
       - name: Set dev environment variables
         run: |
+          echo "TARGET=dev" >> $GITHUB_ENV
           echo "ACCOUNT=vna27887.us-east-1" >> $GITHUB_ENV
           echo "REGION=us-east-1" >> $GITHUB_ENV
           echo "SCHEMA=ADMIN" >> $GITHUB_ENV

--- a/.github/workflows/dbt_run_template_dev_refresh.yml
+++ b/.github/workflows/dbt_run_template_dev_refresh.yml
@@ -7,7 +7,7 @@ jobs:
   run_dbt_jobs_refresh:
     runs-on: ubuntu-latest
     environment:
-      name: workflow_prod
+      name: workflow_secrets
 
     steps:
       - uses: actions/checkout@v3
@@ -51,7 +51,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: run_dbt_jobs_refresh
     environment:
-      name: workflow_dev
+      name: workflow_secrets
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/dbt_run_template_dev_refresh.yml
+++ b/.github/workflows/dbt_run_template_dev_refresh.yml
@@ -1,0 +1,93 @@
+name: dbt_run_template_dev_refresh
+
+on:
+  workflow_call:
+          
+jobs:
+  run_dbt_jobs_refresh:
+    runs-on: ubuntu-latest
+    environment:
+      name: workflow_prod
+
+    steps:
+      - uses: actions/checkout@v3
+      
+      - name: Extract project & profile names from dbt_project.yml
+        id: project-name
+        run: |
+          PROFILE_NAME=$(grep "^profile:" dbt_project.yml | sed 's/^profile:[[:space:]]*"//' | sed 's/".*$//')
+          PROJECT_NAME=$(grep "^name:" dbt_project.yml | sed 's/^name:[[:space:]]*"//' | sed 's/".*$//')
+          echo "PROFILE_NAME=$PROFILE_NAME" >> $GITHUB_ENV
+          echo "PROJECT_NAME=$PROJECT_NAME" >> $GITHUB_ENV
+          echo "PROFILE_NAME: $PROFILE_NAME"
+          echo "PROJECT_NAME: $PROJECT_NAME"
+      
+      - name: Set production environment variables
+        run: |
+          echo "ACCOUNT=vna27887.us-east-1" >> $GITHUB_ENV
+          echo "REGION=us-east-1" >> $GITHUB_ENV
+          echo "SCHEMA=ADMIN" >> $GITHUB_ENV
+          echo "DATABASE=$PROFILE_NAME" >> $GITHUB_ENV
+          echo "ROLE=DBT_CLOUD_$PROFILE_NAME" >> $GITHUB_ENV
+          echo "USER=DBT_CLOUD_$PROFILE_NAME" >> $GITHUB_ENV
+          echo "WAREHOUSE=DBT_CLOUD" >> $GITHUB_ENV
+          echo "PASSWORD=${{ secrets.PASSWORD }}" >> $GITHUB_ENV
+
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
+          cache: "pip"
+
+      - name: Install dependencies
+        run: |
+          pip install -r requirements.txt
+          dbt deps
+      
+      - name: Run Dev Refresh
+        run: |
+          dbt run-operation fsc_evm.run_sp_create_prod_clone
+
+  run_dbt_jobs_udfs:
+    runs-on: ubuntu-latest
+    needs: run_dbt_jobs_refresh
+    environment:
+      name: workflow_dev
+
+    steps:
+      - uses: actions/checkout@v3
+      
+      - name: Extract project & profile names from dbt_project.yml
+        id: project-name
+        run: |
+          PROFILE_NAME=$(grep "^profile:" dbt_project.yml | sed 's/^profile:[[:space:]]*"//' | sed 's/".*$//')
+          PROJECT_NAME=$(grep "^name:" dbt_project.yml | sed 's/^name:[[:space:]]*"//' | sed 's/".*$//')
+          echo "PROFILE_NAME=$PROFILE_NAME" >> $GITHUB_ENV
+          echo "PROJECT_NAME=$PROJECT_NAME" >> $GITHUB_ENV
+          echo "PROFILE_NAME: $PROFILE_NAME"
+          echo "PROJECT_NAME: $PROJECT_NAME"
+      
+      - name: Set dev environment variables
+        run: |
+          echo "ACCOUNT=vna27887.us-east-1" >> $GITHUB_ENV
+          echo "REGION=us-east-1" >> $GITHUB_ENV
+          echo "SCHEMA=ADMIN" >> $GITHUB_ENV
+          echo "DATABASE=${PROFILE_NAME}_DEV" >> $GITHUB_ENV
+          echo "ROLE=INTERNAL_DEV" >> $GITHUB_ENV
+          echo "USER=DBT_CLOUD_$PROFILE_NAME" >> $GITHUB_ENV
+          echo "WAREHOUSE=DBT" >> $GITHUB_ENV
+          echo "PASSWORD=${{ secrets.PASSWORD }}" >> $GITHUB_ENV
+
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
+          cache: "pip"
+
+      - name: Install dependencies
+        run: |
+          pip install -r requirements.txt
+          dbt deps
+
+      - name: Run Recreate UDFs
+        run: |
+          dbt run-operation fsc_utils.create_evm_streamline_udfs --vars '{"UPDATE_UDFS_AND_SPS":True}' -t dev
+          dbt run -s livequery_models.deploy.core._live --vars '{"UPDATE_UDFS_AND_SPS":True}' -t dev

--- a/.github/workflows/dbt_run_template_docs_update.yml
+++ b/.github/workflows/dbt_run_template_docs_update.yml
@@ -24,6 +24,7 @@ jobs:
       
       - name: Set production environment variables
         run: |
+          echo "TARGET=prod" >> $GITHUB_ENV
           echo "ACCOUNT=vna27887.us-east-1" >> $GITHUB_ENV
           echo "REGION=us-east-1" >> $GITHUB_ENV
           echo "SCHEMA=ADMIN" >> $GITHUB_ENV

--- a/.github/workflows/dbt_run_template_docs_update.yml
+++ b/.github/workflows/dbt_run_template_docs_update.yml
@@ -7,7 +7,7 @@ jobs:
   run_dbt_jobs_refresh:
     runs-on: ubuntu-latest
     environment:
-      name: workflow_prod
+      name: workflow_secrets
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/dbt_run_template_docs_update.yml
+++ b/.github/workflows/dbt_run_template_docs_update.yml
@@ -1,0 +1,79 @@
+name: dbt_run_template_docs_update
+
+on:
+  workflow_call:
+          
+jobs:
+  run_dbt_jobs_refresh:
+    runs-on: ubuntu-latest
+    environment:
+      name: workflow_prod
+
+    steps:
+      - uses: actions/checkout@v3
+      
+      - name: Extract project & profile names from dbt_project.yml
+        id: project-name
+        run: |
+          PROFILE_NAME=$(grep "^profile:" dbt_project.yml | sed 's/^profile:[[:space:]]*"//' | sed 's/".*$//')
+          PROJECT_NAME=$(grep "^name:" dbt_project.yml | sed 's/^name:[[:space:]]*"//' | sed 's/".*$//')
+          echo "PROFILE_NAME=$PROFILE_NAME" >> $GITHUB_ENV
+          echo "PROJECT_NAME=$PROJECT_NAME" >> $GITHUB_ENV
+          echo "PROFILE_NAME: $PROFILE_NAME"
+          echo "PROJECT_NAME: $PROJECT_NAME"
+      
+      - name: Set production environment variables
+        run: |
+          echo "ACCOUNT=vna27887.us-east-1" >> $GITHUB_ENV
+          echo "REGION=us-east-1" >> $GITHUB_ENV
+          echo "SCHEMA=ADMIN" >> $GITHUB_ENV
+          echo "DATABASE=$PROFILE_NAME" >> $GITHUB_ENV
+          echo "ROLE=DBT_CLOUD_$PROFILE_NAME" >> $GITHUB_ENV
+          echo "USER=DBT_CLOUD_$PROFILE_NAME" >> $GITHUB_ENV
+          echo "WAREHOUSE=DBT_CLOUD" >> $GITHUB_ENV
+          echo "PASSWORD=${{ secrets.PASSWORD }}" >> $GITHUB_ENV
+
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
+          cache: "pip"
+
+      - name: Install dependencies
+        run: |
+          pip install -r requirements.txt
+          dbt deps
+      
+      - name: refresh ddl for datashare
+        run: |
+          cnt=$(dbt ls -m fsc_utils.datashare._datashare___create_gold | wc -l ); if [ $cnt -eq 1 ]; then dbt run -m fsc_utils.datashare._datashare___create_gold; fi; 
+
+      - name: checkout docs branch
+        run: |
+          git checkout -B docs origin/main
+
+      - name: generate dbt docs
+        run: dbt docs generate -t prod
+
+      - name: move files to docs directory
+        run: |
+          mkdir -p ./docs
+          cp target/{catalog.json,manifest.json,index.html} docs/
+
+      - name: clean up target directory
+        run: dbt clean
+
+      - name: check for changes
+        run: git status
+
+      - name: stage changed files
+        run: git add .
+
+      - name: commit changed files
+        run: |
+          git config user.email "abc@xyz"
+          git config user.name "github-actions"
+          git commit -am "Auto-update docs"
+
+      - name: push changes to docs
+        run: |
+          git push -f --set-upstream origin docs

--- a/.github/workflows/dbt_run_template_integration_test.yml
+++ b/.github/workflows/dbt_run_template_integration_test.yml
@@ -8,24 +8,15 @@ on:
         type: string
         default: DBT_CLOUD
       environment:
-        required: false
-        type: string
-        default: workflow_prod
-      command_name:
         required: true
         type: string
-        default: Run DBT Command
       command:
         required: true
         type: string
-      command_name_2:
+      python_version:
         required: false
         type: string
-        default: Run DBT Command 2 (if enabled)
-      command_2:
-        required: false
-        type: string
-        default: ""
+        default: "3.10"
           
 jobs:
   run_dbt_jobs:
@@ -70,7 +61,7 @@ jobs:
           
       - uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
+          python-version: ${{ inputs.python_version }}
           cache: "pip"
 
       - name: Install dependencies
@@ -78,11 +69,14 @@ jobs:
           pip install -r requirements.txt
           dbt deps
       
-      - name: ${{inputs.command_name}}
+      - name: Run DBT Jobs
         run: |
           ${{ inputs.command }}
-
-      - name: ${{inputs.command_name_2}}
-        if: "${{ inputs.command_2 != '' }}"
-        run: |
-          ${{ inputs.command_2 }}
+          
+      - name: Store logs
+        uses: actions/upload-artifact@v4
+        with:
+          name: dbt-logs
+          path: |
+            logs
+            target

--- a/.github/workflows/dbt_run_template_integration_test.yml
+++ b/.github/workflows/dbt_run_template_integration_test.yml
@@ -40,6 +40,7 @@ jobs:
       
       - name: Set environment variables
         run: |
+          echo "TARGET=${{ inputs.target }}" >> $GITHUB_ENV
           echo "ACCOUNT=vna27887.us-east-1" >> $GITHUB_ENV
           echo "REGION=us-east-1" >> $GITHUB_ENV
           echo "SCHEMA=ADMIN" >> $GITHUB_ENV

--- a/.github/workflows/dbt_run_template_integration_test.yml
+++ b/.github/workflows/dbt_run_template_integration_test.yml
@@ -7,9 +7,10 @@ on:
         required: false
         type: string
         default: DBT_CLOUD
-      environment:
-        required: true
+      target:
+        required: false
         type: string
+        default: prod
       command:
         required: true
         type: string
@@ -22,7 +23,7 @@ jobs:
   run_dbt_jobs:
     runs-on: ubuntu-latest
     environment:
-      name: ${{ inputs.environment }}
+      name: workflow_secrets
 
     steps:
       - uses: actions/checkout@v3
@@ -45,11 +46,11 @@ jobs:
           echo "USER=DBT_CLOUD_$PROFILE_NAME" >> $GITHUB_ENV  
           echo "PASSWORD=${{ secrets.PASSWORD }}" >> $GITHUB_ENV
           
-          if [[ "${{ inputs.environment }}" == *"prod"* ]]; then
+          if [[ "${{ inputs.target }}" == *"prod"* ]]; then
             echo "DATABASE=$PROFILE_NAME" >> $GITHUB_ENV
             echo "ROLE=DBT_CLOUD_$PROFILE_NAME" >> $GITHUB_ENV
             echo "WAREHOUSE=DBT_CLOUD" >> $GITHUB_ENV
-          elif [[ "${{ inputs.environment }}" == *"test"* ]]; then
+          elif [[ "${{ inputs.target }}" == *"test"* ]]; then
             echo "DATABASE=$PROFILE_NAME" >> $GITHUB_ENV
             echo "ROLE=DBT_CLOUD_$PROFILE_NAME" >> $GITHUB_ENV
             echo "WAREHOUSE=DBT_TEST" >> $GITHUB_ENV

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -37,6 +37,8 @@ models:
     main_package: # Only enable models that are required to run in the fsc_evm environment
       variables:
         +enabled: true
+      github_actions:
+        +enabled: true
 
 vars:
   "dbt_date:time_zone": GMT

--- a/macros/global/variables/project_vars/fsc_evm_vars.sql
+++ b/macros/global/variables/project_vars/fsc_evm_vars.sql
@@ -1,6 +1,7 @@
 {% macro fsc_evm_vars() %}
     {% set vars = {
-        'GLOBAL_PROJECT_NAME': 'fsc_evm'
+        'GLOBAL_PROJECT_NAME': 'fsc_evm',
+        'MAIN_GHA_CHAINHEAD_SCHEDULE': '1,31 * * * *'
     } %}
     
     {{ return(vars) }}

--- a/macros/global/variables/project_vars/fsc_evm_vars.sql
+++ b/macros/global/variables/project_vars/fsc_evm_vars.sql
@@ -1,7 +1,6 @@
 {% macro fsc_evm_vars() %}
     {% set vars = {
-        'GLOBAL_PROJECT_NAME': 'fsc_evm',
-        'MAIN_GHA_CHAINHEAD_SCHEDULE': '1,31 * * * *'
+        'GLOBAL_PROJECT_NAME': 'fsc_evm'
     } %}
     
     {{ return(vars) }}

--- a/macros/global/variables/return_vars.sql
+++ b/macros/global/variables/return_vars.sql
@@ -20,6 +20,9 @@
   {% set ns.GLOBAL_SILVER_FR_ENABLED = none if get_var('GLOBAL_SILVER_FR_ENABLED', false) else false %} 
   {% set ns.GLOBAL_GOLD_FR_ENABLED = none if get_var('GLOBAL_GOLD_FR_ENABLED', false) else false %} 
   {% set ns.GLOBAL_STREAMLINE_FR_ENABLED = none if get_var('GLOBAL_STREAMLINE_FR_ENABLED', false) else false %} 
+
+  {# GHA Workflow Variables #}
+  {% set ns.MAIN_GHA_CHAINHEAD_SCHEDULE = get_var('MAIN_GHA_CHAINHEAD_SCHEDULE', '0,30 * * * *') %}
   
   {# Core Variables #}
   {% set ns.MAIN_CORE_RECEIPTS_BY_HASH_ENABLED = get_var('MAIN_CORE_RECEIPTS_BY_HASH_ENABLED', false) %}

--- a/macros/global/variables/return_vars.sql
+++ b/macros/global/variables/return_vars.sql
@@ -22,7 +22,18 @@
   {% set ns.GLOBAL_STREAMLINE_FR_ENABLED = none if get_var('GLOBAL_STREAMLINE_FR_ENABLED', false) else false %} 
 
   {# GHA Workflow Variables #}
-  {% set ns.MAIN_GHA_CHAINHEAD_SCHEDULE = get_var('MAIN_GHA_CHAINHEAD_SCHEDULE', '0,30 * * * *') %}
+  {% set ns.MAIN_GHA_STREAMLINE_CHAINHEAD_CRON = get_var('MAIN_GHA_STREAMLINE_CHAINHEAD_CRON', '0,30 * * * *') %}
+  {% set ns.MAIN_GHA_SCHEDULED_MAIN_CRON = get_var('MAIN_GHA_SCHEDULED_MAIN_CRON', none) %}
+  {% set ns.MAIN_GHA_SCHEDULED_CURATED_CRON = get_var('MAIN_GHA_SCHEDULED_CURATED_CRON', none) %}
+  {% set ns.MAIN_GHA_SCHEDULED_ABIS_CRON = get_var('MAIN_GHA_SCHEDULED_ABIS_CRON', none) %}
+  {% set ns.MAIN_GHA_SCHEDULED_SCORES_CRON = get_var('MAIN_GHA_SCHEDULED_SCORES_CRON', none) %}
+  {% set ns.MAIN_GHA_TEST_DAILY_CRON = get_var('MAIN_GHA_TEST_DAILY_CRON', none) %}
+  {% set ns.MAIN_GHA_TEST_INTRADAY_CRON = get_var('MAIN_GHA_TEST_INTRADAY_CRON', none) %}
+  {% set ns.MAIN_GHA_TEST_MONTHLY_CRON = get_var('MAIN_GHA_TEST_MONTHLY_CRON', none) %}
+  {% set ns.MAIN_GHA_HEAL_MODELS_CRON = get_var('MAIN_GHA_HEAL_MODELS_CRON', none) %}
+  {% set ns.MAIN_GHA_FULL_OBSERVABILITY_CRON = get_var('MAIN_GHA_FULL_OBSERVABILITY_CRON', none) %}
+  {% set ns.MAIN_GHA_DEV_REFRESH_CRON = get_var('MAIN_GHA_DEV_REFRESH_CRON', none) %}
+  {% set ns.MAIN_GHA_STREAMLINE_DECODER_HISTORY_CRON = get_var('MAIN_GHA_STREAMLINE_DECODER_HISTORY_CRON', none) %}
   
   {# Core Variables #}
   {% set ns.MAIN_CORE_RECEIPTS_BY_HASH_ENABLED = get_var('MAIN_CORE_RECEIPTS_BY_HASH_ENABLED', false) %}

--- a/macros/main_package/github_actions/generate_workflow_schedules.sql
+++ b/macros/main_package/github_actions/generate_workflow_schedules.sql
@@ -1,0 +1,75 @@
+{% macro generate_workflow_schedules(chainhead_schedule) %}
+
+{# Parse chainhead schedule #}
+{% set chainhead_components = chainhead_schedule.split(' ') %}
+{% set chainhead_minutes = chainhead_components[0] %}
+{% set chainhead_minutes_list = chainhead_minutes.split(',') | map('int') | list %}
+{% set max_chainhead_minute = chainhead_minutes_list | max %}
+
+{# Generate a repo_id based on database name length to ensure unique schedules #}
+{% set db_name = target.database %}
+{% set repo_id = db_name|length % 12 %}
+
+{# Helper function for root offset, in minutes #}
+{% set root_offset = {} %}
+{% for offset in range(0, 60) %}
+    {% do root_offset.update({offset: ((max_chainhead_minute + offset) % 60) | string}) %}
+{% endfor %}
+
+{# Schedule templates with complete cron format #}
+{% set schedule_templates = {
+    'hourly': '{minute} * * * *',
+    'every_4_hours': '{minute} */4 * * *',
+    'daily': '{minute} {hour} * * *',
+    'weekly': '{minute} {hour} * * {day}',
+    'monthly': '{minute} {hour} 28 * *'
+} %}
+
+{# Define workflow definitions #}
+{% set workflow_definitions = [
+    {'name': 'dbt_run_streamline_chainhead', 'cadence': 'root', 'root_schedule': chainhead_schedule},
+    {'name': 'dbt_run_scheduled_main', 'cadence': 'hourly', 'root_offset': 15},
+    {'name': 'dbt_run_scheduled_decoder', 'cadence': 'hourly', 'root_offset': 30},
+    {'name': 'dbt_run_scheduled_curated', 'cadence': 'every_4_hours', 'root_offset': 30},
+    {'name': 'dbt_run_scheduled_abis', 'cadence': 'daily', 'root_offset': 20, 'hour': 1},
+    {'name': 'dbt_run_scheduled_scores', 'cadence': 'daily', 'root_offset': 35, 'hour': 2},
+    {'name': 'dbt_test_daily', 'cadence': 'daily', 'root_offset': 50, 'hour': 3},
+    {'name': 'dbt_test_intraday', 'cadence': 'hourly', 'root_offset': 50},
+    {'name': 'dbt_test_monthly', 'cadence': 'monthly', 'root_offset': 20, 'hour': 1},
+    {'name': 'dbt_run_heal_models', 'cadence': 'weekly', 'root_offset': 45, 'hour': 6, 'day': 0},
+    {'name': 'dbt_run_full_observability', 'cadence': 'monthly', 'root_offset': 25, 'hour': 2},
+    {'name': 'dbt_run_dev_refresh', 'cadence': 'weekly', 'root_offset': 40, 'hour': 7, 'day': 1},
+    {'name': 'dbt_run_streamline_decoder_history', 'cadence': 'weekly', 'root_offset': 30, 'hour': 3, 'day': 6}
+] %}
+
+{# Generate all workflow schedules #}
+{% for workflow in workflow_definitions %}
+
+{# Helper variables for template replacement #}
+{% set template = schedule_templates[workflow.cadence] %}
+{% set minute_val = root_offset[workflow.root_offset] %}
+{% set hour_val = (workflow.get('hour', 0) + repo_id) % 24 %}
+{% set day_val = workflow.get('day', 0) %}
+
+    SELECT 
+        '{{ workflow.name }}' AS workflow_name,
+        {% if workflow.cadence == 'root' %}
+            '{{ workflow.root_schedule }}'
+        {% else %}
+            
+            {% if workflow.cadence == 'hourly' or workflow.cadence == 'every_4_hours' %}
+                '{{ template.replace("{minute}", minute_val) }}'
+            {% elif workflow.cadence == 'daily' or workflow.cadence == 'monthly' %}
+                '{{ template.replace("{minute}", minute_val).replace("{hour}", hour_val | string) }}'
+            {% elif workflow.cadence == 'weekly' %}
+                '{{ template.replace("{minute}", minute_val).replace("{hour}", hour_val | string).replace("{day}", day_val | string) }}'
+            {% endif %}
+        {% endif %} AS workflow_schedule,
+        '{{ workflow.cadence }}' AS cadence
+    
+    {% if not loop.last %}
+        UNION ALL
+    {% endif %}
+{% endfor %}
+
+{% endmacro %}

--- a/macros/main_package/github_actions/workflow_tasks.sql
+++ b/macros/main_package/github_actions/workflow_tasks.sql
@@ -1,0 +1,181 @@
+{% macro create_gha_tasks() %}
+    {% set query %}
+SELECT
+    task_name,
+    workflow_name,
+    workflow_schedule
+FROM
+    {{ ref('github_actions__tasks') }}
+
+    {% endset %}
+    {% set results = run_query(query) %}
+    {% if execute and results is not none %}
+        {% set results_list = results.rows %}
+    {% else %}
+        {% set results_list = [] %}
+    {% endif %}
+
+    {% set prod_db = target.database.lower().replace(
+        '_dev',
+        ''
+    ) %}
+    {% for result in results_list %}
+        {% set task_name = result [0] %}
+        {% set workflow_name = result [1] %}
+        {% set workflow_schedule = result [2] %}
+        {% set sql %}
+        EXECUTE IMMEDIATE 'CREATE OR REPLACE TASK github_actions.{{ task_name }} WAREHOUSE = DBT_CLOUD SCHEDULE = \'USING CRON {{ workflow_schedule }} UTC\' COMMENT = \'Task to trigger {{ workflow_name }}.yml workflow according to {{ workflow_schedule }}\' AS DECLARE rs resultset; output string; BEGIN rs := (SELECT github_actions.workflow_dispatches(\'FlipsideCrypto\', \'{{ prod_db }}-models\', \'{{ workflow_name }}.yml\', NULL):status_code::int AS status_code); SELECT LISTAGG($1, \';\') INTO :output FROM TABLE(result_scan(LAST_QUERY_ID())) LIMIT 1; CALL SYSTEM$SET_RETURN_VALUE(:output); END;' {% endset %}
+        {% do run_query(sql) %}
+        {% if var("START_GHA_TASKS") %}
+            {% if target.database.lower() == prod_db %}
+                {% set sql %}
+                ALTER task github_actions.{{ task_name }}
+                resume;
+{% endset %}
+                {% do run_query(sql) %}
+            {% endif %}
+        {% endif %}
+    {% endfor %}
+{% endmacro %}
+
+{% macro gha_tasks_view() %}
+SELECT
+    workflow_name,
+    concat_ws(
+        '_',
+        'TRIGGER',
+        UPPER(workflow_name)
+    ) AS task_name,
+    workflow_schedule
+FROM
+    {{ source(
+        'github_actions',
+        'workflows'
+    ) }}
+{% endmacro %}
+
+{% macro gha_task_history_view() %}
+    {% set query %}
+SELECT
+    DISTINCT task_name
+FROM
+    {{ ref('github_actions__tasks') }}
+
+    {% endset %}
+    {% set results = run_query(query) %}
+    {% if execute and results is not none %}
+        {% set results_list = results.rows %}
+    {% else %}
+        {% set results_list = [] %}
+    {% endif %}
+
+    WITH task_history_data AS (
+        SELECT
+            *
+        FROM
+            ({% for result in results_list %}
+            SELECT
+                NAME AS task_name, completed_time, return_value, state, database_name, schema_name, scheduled_time, query_start_time
+            FROM
+                TABLE(information_schema.task_history(scheduled_time_range_start => DATEADD('hour', -24, CURRENT_TIMESTAMP()), task_name => '{{ result[0]}}')) {% if not loop.last %}
+                UNION ALL
+                {% endif %}
+            {% endfor %}) AS subquery
+        WHERE
+            database_name = '{{ target.database }}'
+            AND schema_name = 'GITHUB_ACTIONS')
+        SELECT
+            *
+        FROM
+            task_history_data
+{% endmacro %}
+
+{% macro gha_task_schedule_view() %}
+    WITH base AS (
+        SELECT
+            w.workflow_name AS workflow_name,
+            w.workflow_schedule AS workflow_schedule,
+            w.task_name AS task_name,
+            t.timestamp AS scheduled_time
+        FROM
+            {{ ref('github_actions__tasks') }} AS w
+            CROSS JOIN TABLE(
+                utils.udf_cron_to_prior_timestamps(
+                    w.workflow_name,
+                    w.workflow_schedule
+                )
+            ) AS t
+    )
+SELECT
+    task_name,
+    workflow_name,
+    workflow_schedule,
+    scheduled_time
+FROM
+    base
+{% endmacro %}
+
+{% macro gha_task_performance_view() %}
+SELECT
+    s.task_name,
+    s.workflow_name,
+    s.scheduled_time,
+    h.return_value
+FROM
+    {{ ref('github_actions__task_schedule') }}
+    s
+    LEFT JOIN {{ ref('github_actions__task_history') }}
+    h
+    ON s.task_name = h.task_name
+    AND TO_TIMESTAMP_NTZ(
+        s.scheduled_time
+    ) BETWEEN TO_TIMESTAMP_NTZ(DATEADD(MINUTE, -1, h.scheduled_time))
+    AND TO_TIMESTAMP_NTZ(DATEADD(MINUTE, 1, h.scheduled_time))
+    AND TRY_TO_NUMBER(
+        h.return_value
+    ) BETWEEN 200
+    AND 299
+    AND h.state = 'SUCCEEDED'
+ORDER BY
+    task_name,
+    scheduled_time
+{% endmacro %}
+
+{% macro gha_task_current_status_view() %}
+    WITH base AS (
+        SELECT
+            task_name,
+            workflow_name,
+            scheduled_time,
+            return_value,
+            return_value IS NOT NULL AS was_successful
+        FROM
+            {{ ref('github_actions__task_performance') }}
+            qualify ROW_NUMBER() over (
+                PARTITION BY task_name
+                ORDER BY
+                    scheduled_time DESC
+            ) <= 2
+    )
+SELECT
+    task_name,
+    workflow_name,
+    MAX(scheduled_time) AS recent_scheduled_time,
+    MIN(scheduled_time) AS prior_scheduled_time,
+    SUM(IFF(return_value = 204, 1, 0)) AS successes,
+    successes > 0 AS pipeline_active
+FROM
+    base
+GROUP BY
+    task_name,
+    workflow_name
+{% endmacro %}
+
+{% macro alter_gha_task(
+        task_name,
+        task_action
+    ) %}
+    {% set sql %}
+    EXECUTE IMMEDIATE 'ALTER TASK IF EXISTS github_actions.{{ task_name }} {{ task_action }};' {% endset %}
+    {% do run_query(sql) %}
+{% endmacro %}

--- a/macros/main_package/github_actions/workflow_tasks.sql
+++ b/macros/main_package/github_actions/workflow_tasks.sql
@@ -173,10 +173,14 @@ GROUP BY
 {% endmacro %}
 
 {% macro alter_gha_task(
-        task_name,
+        task_names,
         task_action
     ) %}
-    {% set sql %}
-    EXECUTE IMMEDIATE 'ALTER TASK IF EXISTS github_actions.{{ task_name }} {{ task_action }};' {% endset %}
-    {% do run_query(sql) %}
+    {% set task_list = task_names.split(',') %}
+    {% for task_name in task_list %}
+        {% set task_name = task_name.strip() %}
+        {% set sql %}
+        EXECUTE IMMEDIATE 'ALTER TASK IF EXISTS github_actions.{{ task_name }} {{ task_action }};' {% endset %}
+        {% do run_query(sql) %}
+    {% endfor %}
 {% endmacro %}

--- a/macros/main_package/github_actions/workflow_tasks.sql
+++ b/macros/main_package/github_actions/workflow_tasks.sql
@@ -46,7 +46,8 @@ SELECT
         'TRIGGER',
         UPPER(workflow_name)
     ) AS task_name,
-    workflow_schedule
+    workflow_schedule,
+    cadence
 FROM
     {{ source(
         'github_actions',

--- a/models/main_package/github_actions/github_actions__current_task_status.sql
+++ b/models/main_package/github_actions/github_actions__current_task_status.sql
@@ -6,4 +6,4 @@
     tags = ['gha_tasks']
 ) }}
 
-{{ fsc_utils.gha_task_current_status_view() }}
+{{ gha_task_current_status_view() }}

--- a/models/main_package/github_actions/github_actions__task_history.sql
+++ b/models/main_package/github_actions/github_actions__task_history.sql
@@ -6,4 +6,4 @@
     tags = ['gha_tasks']
 ) }}
 
-{{ fsc_utils.gha_task_history_view() }}
+{{ gha_task_history_view() }}

--- a/models/main_package/github_actions/github_actions__task_performance.sql
+++ b/models/main_package/github_actions/github_actions__task_performance.sql
@@ -6,4 +6,4 @@
     tags = ['gha_tasks']
 ) }}
 
-{{ fsc_utils.gha_task_performance_view() }}
+{{ gha_task_performance_view() }}

--- a/models/main_package/github_actions/github_actions__task_schedule.sql
+++ b/models/main_package/github_actions/github_actions__task_schedule.sql
@@ -6,4 +6,4 @@
     tags = ['gha_tasks']
 ) }}
 
-{{ fsc_utils.gha_task_schedule_view() }}
+{{ gha_task_schedule_view() }}

--- a/models/main_package/github_actions/github_actions__tasks.sql
+++ b/models/main_package/github_actions/github_actions__tasks.sql
@@ -6,4 +6,4 @@
     tags = ['gha_tasks']
 ) }}
 
-{{ fsc_utils.gha_tasks_view() }}
+{{ gha_tasks_view() }}

--- a/models/main_package/github_actions/github_actions__workflows.sql
+++ b/models/main_package/github_actions/github_actions__workflows.sql
@@ -9,4 +9,4 @@
     tags = ['gha_tasks']
 ) }}
 
-{{ generate_workflow_schedules(vars.MAIN_GHA_CHAINHEAD_SCHEDULE) }}
+{{ generate_workflow_schedules(vars.MAIN_GHA_STREAMLINE_CHAINHEAD_CRON) }}

--- a/models/main_package/github_actions/github_actions__workflows.sql
+++ b/models/main_package/github_actions/github_actions__workflows.sql
@@ -1,0 +1,12 @@
+{# Get variables #}
+{% set vars = return_vars() %}
+
+{# Log configuration details #}
+{{ log_model_details() }}
+
+{{ config(
+    materialized = 'table',
+    tags = ['gha_tasks']
+) }}
+
+{{ generate_workflow_schedules(vars.MAIN_GHA_CHAINHEAD_SCHEDULE) }}

--- a/package-lock.yml
+++ b/package-lock.yml
@@ -7,8 +7,10 @@ packages:
   version: 1.0.0
 - git: https://github.com/FlipsideCrypto/fsc-utils.git
   revision: c3ab97e8e06d31e8c6f63819714e0a2d45c45e82
+- package: get-select/dbt_snowflake_query_tags
+  version: 2.5.0
 - package: calogica/dbt_date
   version: 0.7.2
 - git: https://github.com/FlipsideCrypto/livequery-models.git
   revision: b024188be4e9c6bc00ed77797ebdc92d351d620e
-sha1_hash: 1d4f5860d5238701e5cca223ce198c158220b390
+sha1_hash: 9055cfc18887ed4acf4d733445e299939a1176f8


### PR DESCRIPTION
**NOTES**
* Builds workflow template .yml files and refactors environment variables:
  - Only requires a GitHub environment named `workflow_secrets`
  - Requires `PASSWORD` set under env secrets for the `DBT_CLOUD_<DATABASE>` `role`
* Generates workflow schedules macro to automate scheduling:
  - Uses chainhead cron schedule as the root for the schedule (can tweak timing requirements as needed)
  - Supports overriding schedules with workflow-specific cron variables in `return_vars()`
* Migrates `github_actions__workflows` from seed CSV to a table:
  - Now accepts the root chainhead cron schedule as a variable
* Updates `alter_gha_task` macro to accept a list of workflows to resume/suspend in bulk
  - Can create makefile commands to `RESUME` or `SUSPEND` workflows based on deployment phases or tiers
  - Maintains backward compatibility with single entries
  - No process changes required for existing implementations
* Adds new `alter_all_gha_tasks` macro and workflow template to suspend or resume all tasks in a repo at once
* Relocates GHA workflow task macros fsc-utils to fsc-evm

View examples of how to call the templates in [evm-models-template](https://github.com/FlipsideCrypto/evm-models-template/tree/main/.github/workflows)