### PR TITLE
cluster

### DIFF
--- a/models/main_package/core/silver/silver__confirm_blocks.sql
+++ b/models/main_package/core/silver/silver__confirm_blocks.sql
@@ -22,7 +22,6 @@
     materialized = "incremental",
     incremental_strategy = 'delete+insert',
     unique_key = "block_number",
-    cluster_by = ['modified_timestamp::DATE'],
     post_hook = "ALTER TABLE {{ this }} ADD SEARCH OPTIMIZATION on equality(block_number)",
     incremental_predicates = [fsc_evm.standard_predicate()],
     full_refresh = vars.GLOBAL_SILVER_FR_ENABLED,


### PR DESCRIPTION
Removes cluster_by for confirm_blocks FR to avoid re-clustering costs

Requires `v4.0.0-beta.27`