### PR TITLE
Update/nft-core-tag

### DIFF
--- a/models/main_package/core/nft/nft__ez_nft_transfers.sql
+++ b/models/main_package/core/nft/nft__ez_nft_transfers.sql
@@ -12,7 +12,7 @@
     incremental_predicates = [fsc_evm.standard_predicate()],
     full_refresh = vars.GLOBAL_GOLD_FR_ENABLED,
     post_hook = "ALTER TABLE {{ this }} ADD SEARCH OPTIMIZATION ON EQUALITY(origin_from_address, origin_to_address, from_address, to_address, origin_function_signature), SUBSTRING(origin_from_address, origin_to_address, from_address, to_address, origin_function_signature)",
-    tags = ['gold','nft','ez','phase_2']
+    tags = ['gold','core','ez','phase_2']
 ) }}
 
 WITH base AS (


### PR DESCRIPTION
After upgrading to `pre-release/beta.v64+` in downstream repos, remove the `"fsc_evm,tag:gold,tag:nft"` selector from `dbt_run_scheduled_main`