### PR TITLE
AN-6330/test-exclusions

### DIFF
--- a/macros/decoder_package/tests/find_missing_decoded_logs.sql
+++ b/macros/decoder_package/tests/find_missing_decoded_logs.sql
@@ -15,4 +15,5 @@ WHERE
     l.contract_address = '{{ vars.GLOBAL_WRAPPED_NATIVE_ASSET_ADDRESS }}'
     AND l.topics [0] :: STRING = '0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef' -- Transfer
     AND d.ez_decoded_event_logs_id IS NULL
+    AND l.block_timestamp < (SELECT MAX(block_timestamp) - INTERVAL '2 hours' FROM {{ fact_logs_model }})
 {% endtest %}

--- a/macros/main_package/tests/sequence_gaps.sql
+++ b/macros/main_package/tests/sequence_gaps.sql
@@ -34,12 +34,13 @@ FROM
     source
 WHERE
     {{ column_name }} - {{ previous_column }} <> 1
-{% if vars.MAIN_OBSERV_EXCLUSION_LIST_ENABLED and {{ column_name }} == 'block_number' %}
+{% if vars.MAIN_OBSERV_EXCLUSION_LIST_ENABLED and column_name | lower == 'block_number' %}
     AND {{ column_name }} NOT IN (
-        SELECT
-            block_number :: INT
-        FROM
-            observability.exclusion_list
+        SELECT block_number :: INT + 1
+        FROM observability.exclusion_list
+        UNION ALL
+        SELECT block_number :: INT - 1
+        FROM observability.exclusion_list
     )
 {% endif %}
 ORDER BY

--- a/macros/main_package/tests/sequence_gaps.sql
+++ b/macros/main_package/tests/sequence_gaps.sql
@@ -1,0 +1,43 @@
+{% test sequence_gaps(
+    model,
+    partition_by,
+    column_name
+) %}
+{%- set partition_sql = partition_by | join(", ") -%}
+{%- set previous_column = "prev_" ~ column_name -%}
+WITH source AS (
+    SELECT
+        {{ partition_sql + "," if partition_sql }}
+        {{ column_name }},
+        LAG(
+            {{ column_name }},
+            1
+        ) over (
+            {{ "PARTITION BY " ~ partition_sql if partition_sql }}
+            ORDER BY
+                {{ column_name }} ASC
+        ) AS {{ previous_column }}
+    FROM
+        {{ model }}
+)
+SELECT
+    {{ partition_sql + "," if partition_sql }}
+    {{ previous_column }},
+    {{ column_name }},
+    {{ column_name }} - {{ previous_column }}
+    - 1 AS gap
+FROM
+    source
+WHERE
+    {{ column_name }} - {{ previous_column }} <> 1
+{% if vars.MAIN_OBSERV_EXCLUSION_LIST_ENABLED and {{column_name}} = 'block_number' %}
+    AND {{column_name}} NOT IN (
+        SELECT
+            block_number :: INT
+        FROM
+            observability.exclusion_list
+    )
+{% endif %}
+ORDER BY
+    gap DESC 
+{% endtest %}

--- a/macros/main_package/tests/sequence_gaps.sql
+++ b/macros/main_package/tests/sequence_gaps.sql
@@ -5,6 +5,10 @@
 ) %}
 {%- set partition_sql = partition_by | join(", ") -%}
 {%- set previous_column = "prev_" ~ column_name -%}
+
+{# Get variables #}
+{% set vars = return_vars() %}
+
 WITH source AS (
     SELECT
         {{ partition_sql + "," if partition_sql }}
@@ -30,8 +34,8 @@ FROM
     source
 WHERE
     {{ column_name }} - {{ previous_column }} <> 1
-{% if vars.MAIN_OBSERV_EXCLUSION_LIST_ENABLED and {{column_name}} = 'block_number' %}
-    AND {{column_name}} NOT IN (
+{% if vars.MAIN_OBSERV_EXCLUSION_LIST_ENABLED and {{ column_name }} == 'block_number' %}
+    AND {{ column_name }} NOT IN (
         SELECT
             block_number :: INT
         FROM

--- a/macros/main_package/tests/txs_have_traces.sql
+++ b/macros/main_package/tests/txs_have_traces.sql
@@ -30,4 +30,7 @@ WHERE
         AND txs.to_address <> '0x000000000000000000000000000000000000006e'
         AND txs.block_number > 22207817
     {% endif %}
+    {% if vars.GLOBAL_PROJECT_NAME == 'boba' %}
+        AND txs.block_number > 1041894
+    {% endif %}
 {% endtest %}

--- a/models/decoder_package/decoded_logs/gold/tests/test_gold__ez_decoded_event_logs_full.sql
+++ b/models/decoder_package/decoded_logs/gold/tests/test_gold__ez_decoded_event_logs_full.sql
@@ -10,3 +10,12 @@ SELECT
     *
 FROM
     {{ ref('core__ez_decoded_event_logs') }}
+{% if vars.MAIN_OBSERV_EXCLUSION_LIST_ENABLED %}
+WHERE
+    block_number NOT IN (
+        SELECT
+            block_number :: INT
+        FROM
+            observability.exclusion_list
+    )
+{% endif %}

--- a/models/decoder_package/decoded_logs/gold/tests/test_gold__ez_decoded_event_logs_full.sql
+++ b/models/decoder_package/decoded_logs/gold/tests/test_gold__ez_decoded_event_logs_full.sql
@@ -1,3 +1,6 @@
+{# Get variables #}
+{% set vars = return_vars() %}
+
 {# Log configuration details #}
 {{ log_model_details() }}
 

--- a/models/decoder_package/decoded_logs/gold/tests/test_gold__ez_decoded_event_logs_recent.sql
+++ b/models/decoder_package/decoded_logs/gold/tests/test_gold__ez_decoded_event_logs_recent.sql
@@ -1,3 +1,6 @@
+{# Get variables #}
+{% set vars = return_vars() %}
+
 {# Log configuration details #}
 {{ log_model_details() }}
 

--- a/models/decoder_package/decoded_logs/gold/tests/test_gold__ez_decoded_event_logs_recent.sql
+++ b/models/decoder_package/decoded_logs/gold/tests/test_gold__ez_decoded_event_logs_recent.sql
@@ -17,3 +17,12 @@ WHERE
         FROM
             {{ ref('_block_lookback') }}
     )
+{% if vars.MAIN_OBSERV_EXCLUSION_LIST_ENABLED %}
+AND
+    block_number NOT IN (
+        SELECT
+            block_number :: INT
+        FROM
+            observability.exclusion_list
+    )
+{% endif %}

--- a/models/decoder_package/decoded_logs/silver/tests/test_silver__decoded_logs_full.sql
+++ b/models/decoder_package/decoded_logs/silver/tests/test_silver__decoded_logs_full.sql
@@ -1,3 +1,6 @@
+{# Get variables #}
+{% set vars = return_vars() %}
+
 {# Log configuration details #}
 {{ log_model_details() }}
 
@@ -10,3 +13,12 @@ SELECT
     *
 FROM
     {{ ref('silver__decoded_logs') }}
+{% if vars.MAIN_OBSERV_EXCLUSION_LIST_ENABLED %}
+WHERE
+    block_number NOT IN (
+        SELECT
+            block_number :: INT
+        FROM
+            observability.exclusion_list
+    )
+{% endif %}

--- a/models/decoder_package/decoded_logs/silver/tests/test_silver__decoded_logs_recent.sql
+++ b/models/decoder_package/decoded_logs/silver/tests/test_silver__decoded_logs_recent.sql
@@ -1,3 +1,6 @@
+{# Get variables #}
+{% set vars = return_vars() %}
+
 {# Log configuration details #}
 {{ log_model_details() }}
 
@@ -17,3 +20,12 @@ WHERE
         FROM
             {{ ref('_block_lookback') }}
     )
+{% if vars.MAIN_OBSERV_EXCLUSION_LIST_ENABLED %}
+AND
+    block_number NOT IN (
+        SELECT
+            block_number :: INT
+        FROM
+            observability.exclusion_list
+    )
+{% endif %}

--- a/models/main_package/core/gold/tests/blocks/test_gold__fact_blocks_full.sql
+++ b/models/main_package/core/gold/tests/blocks/test_gold__fact_blocks_full.sql
@@ -1,3 +1,6 @@
+{# Get variables #}
+{% set vars = return_vars() %}
+
 {# Log configuration details #}
 {{ log_model_details() }}
 
@@ -10,3 +13,12 @@ SELECT
     *
 FROM
     {{ ref('core__fact_blocks') }}
+{% if vars.MAIN_OBSERV_EXCLUSION_LIST_ENABLED %}
+WHERE
+    block_number NOT IN (
+        SELECT
+            block_number :: INT
+        FROM
+            observability.exclusion_list
+    )
+{% endif %}

--- a/models/main_package/core/gold/tests/blocks/test_gold__fact_blocks_full.yml
+++ b/models/main_package/core/gold/tests/blocks/test_gold__fact_blocks_full.yml
@@ -6,7 +6,7 @@ models:
       - dbt_utils.unique_combination_of_columns:
           combination_of_columns:
             - BLOCK_NUMBER
-      - fsc_utils.sequence_gaps:
+      - fsc_evm.sequence_gaps:
           column_name: BLOCK_NUMBER
           where: BLOCK_TIMESTAMP < CURRENT_DATE - 1
 

--- a/models/main_package/core/gold/tests/blocks/test_gold__fact_blocks_full.yml
+++ b/models/main_package/core/gold/tests/blocks/test_gold__fact_blocks_full.yml
@@ -67,7 +67,6 @@ models:
               regex: 0[xX][0-9a-fA-F]+
       - name: GAS_USED
         tests:
-          - not_null
           - dbt_expectations.expect_column_values_to_be_in_type_list:
               column_type_list:
                 - NUMBER

--- a/models/main_package/core/gold/tests/blocks/test_gold__fact_blocks_recent.sql
+++ b/models/main_package/core/gold/tests/blocks/test_gold__fact_blocks_recent.sql
@@ -1,3 +1,6 @@
+{# Get variables #}
+{% set vars = return_vars() %}
+
 {# Log configuration details #}
 {{ log_model_details() }}
 

--- a/models/main_package/core/gold/tests/blocks/test_gold__fact_blocks_recent.sql
+++ b/models/main_package/core/gold/tests/blocks/test_gold__fact_blocks_recent.sql
@@ -17,3 +17,12 @@ WHERE
         FROM
             {{ ref('_block_lookback') }}
     )
+{% if vars.MAIN_OBSERV_EXCLUSION_LIST_ENABLED %}
+AND
+    block_number NOT IN (
+        SELECT
+            block_number :: INT
+        FROM
+            observability.exclusion_list
+    )
+{% endif %}

--- a/models/main_package/core/gold/tests/blocks/test_gold__fact_blocks_recent.yml
+++ b/models/main_package/core/gold/tests/blocks/test_gold__fact_blocks_recent.yml
@@ -6,7 +6,7 @@ models:
       - dbt_utils.unique_combination_of_columns:
           combination_of_columns:
             - BLOCK_NUMBER
-      - fsc_utils.sequence_gaps:
+      - fsc_evm.sequence_gaps:
           column_name: BLOCK_NUMBER
           config:
             severity: error

--- a/models/main_package/core/gold/tests/blocks/test_gold__fact_blocks_recent.yml
+++ b/models/main_package/core/gold/tests/blocks/test_gold__fact_blocks_recent.yml
@@ -69,7 +69,6 @@ models:
               regex: 0[xX][0-9a-fA-F]+
       - name: GAS_USED
         tests:
-          - not_null
           - dbt_expectations.expect_column_values_to_be_in_type_list:
               column_type_list:
                 - NUMBER

--- a/models/main_package/core/gold/tests/event_logs/test_gold__fact_event_logs_full.sql
+++ b/models/main_package/core/gold/tests/event_logs/test_gold__fact_event_logs_full.sql
@@ -10,3 +10,12 @@ SELECT
     *
 FROM
     {{ ref('core__fact_event_logs') }}
+{% if vars.MAIN_OBSERV_EXCLUSION_LIST_ENABLED %}
+WHERE
+    block_number NOT IN (
+        SELECT
+            block_number :: INT
+        FROM
+            observability.exclusion_list
+    )
+{% endif %}

--- a/models/main_package/core/gold/tests/event_logs/test_gold__fact_event_logs_full.sql
+++ b/models/main_package/core/gold/tests/event_logs/test_gold__fact_event_logs_full.sql
@@ -1,3 +1,6 @@
+{# Get variables #}
+{% set vars = return_vars() %}
+
 {# Log configuration details #}
 {{ log_model_details() }}
 

--- a/models/main_package/core/gold/tests/event_logs/test_gold__fact_event_logs_full.yml
+++ b/models/main_package/core/gold/tests/event_logs/test_gold__fact_event_logs_full.yml
@@ -7,7 +7,7 @@ models:
           combination_of_columns:
             - TX_HASH
             - EVENT_INDEX
-      - fsc_utils.sequence_gaps:
+      - fsc_evm.sequence_gaps:
           partition_by:
             - BLOCK_NUMBER
           column_name: EVENT_INDEX

--- a/models/main_package/core/gold/tests/event_logs/test_gold__fact_event_logs_recent.sql
+++ b/models/main_package/core/gold/tests/event_logs/test_gold__fact_event_logs_recent.sql
@@ -1,3 +1,6 @@
+{# Get variables #}
+{% set vars = return_vars() %}
+
 {# Log configuration details #}
 {{ log_model_details() }}
 

--- a/models/main_package/core/gold/tests/event_logs/test_gold__fact_event_logs_recent.sql
+++ b/models/main_package/core/gold/tests/event_logs/test_gold__fact_event_logs_recent.sql
@@ -17,3 +17,12 @@ WHERE
         FROM
             {{ ref('_block_lookback') }}
     )
+{% if vars.MAIN_OBSERV_EXCLUSION_LIST_ENABLED %}
+AND
+    block_number NOT IN (
+        SELECT
+            block_number :: INT
+        FROM
+            observability.exclusion_list
+    )
+{% endif %}

--- a/models/main_package/core/gold/tests/event_logs/test_gold__fact_event_logs_recent.yml
+++ b/models/main_package/core/gold/tests/event_logs/test_gold__fact_event_logs_recent.yml
@@ -7,7 +7,7 @@ models:
           combination_of_columns:
             - TX_HASH
             - EVENT_INDEX
-      - fsc_utils.sequence_gaps:
+      - fsc_evm.sequence_gaps:
           partition_by:
             - BLOCK_NUMBER
           column_name: EVENT_INDEX

--- a/models/main_package/core/gold/tests/ez_native_transfers/test_gold__ez_native_transfers_full.sql
+++ b/models/main_package/core/gold/tests/ez_native_transfers/test_gold__ez_native_transfers_full.sql
@@ -10,3 +10,12 @@ SELECT
     *
 FROM
     {{ ref('core__ez_native_transfers') }}
+{% if vars.MAIN_OBSERV_EXCLUSION_LIST_ENABLED %}
+WHERE
+    block_number NOT IN (
+        SELECT
+            block_number :: INT
+        FROM
+            observability.exclusion_list
+    )
+{% endif %}

--- a/models/main_package/core/gold/tests/ez_native_transfers/test_gold__ez_native_transfers_full.sql
+++ b/models/main_package/core/gold/tests/ez_native_transfers/test_gold__ez_native_transfers_full.sql
@@ -1,3 +1,6 @@
+{# Get variables #}
+{% set vars = return_vars() %}
+
 {# Log configuration details #}
 {{ log_model_details() }}
 

--- a/models/main_package/core/gold/tests/ez_native_transfers/test_gold__ez_native_transfers_recent.sql
+++ b/models/main_package/core/gold/tests/ez_native_transfers/test_gold__ez_native_transfers_recent.sql
@@ -1,3 +1,6 @@
+{# Get variables #}
+{% set vars = return_vars() %}
+
 {# Log configuration details #}
 {{ log_model_details() }}
 

--- a/models/main_package/core/gold/tests/ez_native_transfers/test_gold__ez_native_transfers_recent.sql
+++ b/models/main_package/core/gold/tests/ez_native_transfers/test_gold__ez_native_transfers_recent.sql
@@ -17,3 +17,12 @@ WHERE
         FROM
             {{ ref('_block_lookback') }}
     )
+{% if vars.MAIN_OBSERV_EXCLUSION_LIST_ENABLED %}
+AND
+    block_number NOT IN (
+        SELECT
+            block_number :: INT
+        FROM
+            observability.exclusion_list
+    )
+{% endif %}

--- a/models/main_package/core/gold/tests/ez_token_transfers/test_gold__ez_token_transfers_full.sql
+++ b/models/main_package/core/gold/tests/ez_token_transfers/test_gold__ez_token_transfers_full.sql
@@ -1,3 +1,6 @@
+{# Get variables #}
+{% set vars = return_vars() %}
+
 {# Log configuration details #}
 {{ log_model_details() }}
 

--- a/models/main_package/core/gold/tests/ez_token_transfers/test_gold__ez_token_transfers_full.sql
+++ b/models/main_package/core/gold/tests/ez_token_transfers/test_gold__ez_token_transfers_full.sql
@@ -10,3 +10,12 @@ SELECT
     *
 FROM
     {{ ref('core__ez_token_transfers') }}
+{% if vars.MAIN_OBSERV_EXCLUSION_LIST_ENABLED %}
+WHERE
+    block_number NOT IN (
+        SELECT
+            block_number :: INT
+        FROM
+            observability.exclusion_list
+    )
+{% endif %}

--- a/models/main_package/core/gold/tests/ez_token_transfers/test_gold__ez_token_transfers_recent.sql
+++ b/models/main_package/core/gold/tests/ez_token_transfers/test_gold__ez_token_transfers_recent.sql
@@ -1,3 +1,6 @@
+{# Get variables #}
+{% set vars = return_vars() %}
+
 {# Log configuration details #}
 {{ log_model_details() }}
 

--- a/models/main_package/core/gold/tests/ez_token_transfers/test_gold__ez_token_transfers_recent.sql
+++ b/models/main_package/core/gold/tests/ez_token_transfers/test_gold__ez_token_transfers_recent.sql
@@ -17,3 +17,12 @@ WHERE
         FROM
             {{ ref('_block_lookback') }}
     )
+{% if vars.MAIN_OBSERV_EXCLUSION_LIST_ENABLED %}
+AND
+    block_number NOT IN (
+        SELECT
+            block_number :: INT
+        FROM
+            observability.exclusion_list
+    )
+{% endif %}

--- a/models/main_package/core/gold/tests/traces/test_gold__fact_traces_full.sql
+++ b/models/main_package/core/gold/tests/traces/test_gold__fact_traces_full.sql
@@ -1,3 +1,6 @@
+{# Get variables #}
+{% set vars = return_vars() %}
+
 {# Log configuration details #}
 {{ log_model_details() }}
 

--- a/models/main_package/core/gold/tests/traces/test_gold__fact_traces_full.sql
+++ b/models/main_package/core/gold/tests/traces/test_gold__fact_traces_full.sql
@@ -10,3 +10,12 @@ SELECT
     *
 FROM
     {{ ref('core__fact_traces') }}
+{% if vars.MAIN_OBSERV_EXCLUSION_LIST_ENABLED %}
+WHERE
+    block_number NOT IN (
+        SELECT
+            block_number :: INT
+        FROM
+            observability.exclusion_list
+    )
+{% endif %}

--- a/models/main_package/core/gold/tests/traces/test_gold__fact_traces_full.yml
+++ b/models/main_package/core/gold/tests/traces/test_gold__fact_traces_full.yml
@@ -90,11 +90,7 @@ models:
         tests:
           - not_null
       - name: GAS
-        tests:
-          - not_null
       - name: GAS_USED
-        tests:
-          - not_null
       - name: ORIGIN_FROM_ADDRESS
         tests:
           - not_null

--- a/models/main_package/core/gold/tests/traces/test_gold__fact_traces_full.yml
+++ b/models/main_package/core/gold/tests/traces/test_gold__fact_traces_full.yml
@@ -7,7 +7,7 @@ models:
           combination_of_columns:
             - TX_HASH
             - TRACE_INDEX
-      - fsc_utils.sequence_gaps:
+      - fsc_evm.sequence_gaps:
           partition_by:
             - TX_HASH
           column_name: TRACE_INDEX

--- a/models/main_package/core/gold/tests/traces/test_gold__fact_traces_recent.sql
+++ b/models/main_package/core/gold/tests/traces/test_gold__fact_traces_recent.sql
@@ -1,3 +1,6 @@
+{# Get variables #}
+{% set vars = return_vars() %}
+
 {# Log configuration details #}
 {{ log_model_details() }}
 

--- a/models/main_package/core/gold/tests/traces/test_gold__fact_traces_recent.sql
+++ b/models/main_package/core/gold/tests/traces/test_gold__fact_traces_recent.sql
@@ -17,3 +17,12 @@ WHERE
         FROM
             {{ ref('_block_lookback') }}
     )
+{% if vars.MAIN_OBSERV_EXCLUSION_LIST_ENABLED %}
+AND
+    block_number NOT IN (
+        SELECT
+            block_number :: INT
+        FROM
+            observability.exclusion_list
+    )
+{% endif %}

--- a/models/main_package/core/gold/tests/traces/test_gold__fact_traces_recent.yml
+++ b/models/main_package/core/gold/tests/traces/test_gold__fact_traces_recent.yml
@@ -90,11 +90,7 @@ models:
         tests:
           - not_null
       - name: GAS
-        tests:
-          - not_null
       - name: GAS_USED
-        tests:
-          - not_null
       - name: ORIGIN_FROM_ADDRESS
         tests:
           - not_null

--- a/models/main_package/core/gold/tests/traces/test_gold__fact_traces_recent.yml
+++ b/models/main_package/core/gold/tests/traces/test_gold__fact_traces_recent.yml
@@ -7,7 +7,7 @@ models:
           combination_of_columns:
             - TX_HASH
             - TRACE_INDEX
-      - fsc_utils.sequence_gaps:
+      - fsc_evm.sequence_gaps:
           partition_by:
             - TX_HASH
           column_name: TRACE_INDEX

--- a/models/main_package/core/gold/tests/transactions/test_gold__fact_transactions_full.sql
+++ b/models/main_package/core/gold/tests/transactions/test_gold__fact_transactions_full.sql
@@ -10,3 +10,12 @@ SELECT
     *
 FROM
     {{ ref('core__fact_transactions') }}
+{% if vars.MAIN_OBSERV_EXCLUSION_LIST_ENABLED %}
+WHERE
+    block_number NOT IN (
+        SELECT
+            block_number :: INT
+        FROM
+            observability.exclusion_list
+    )
+{% endif %}

--- a/models/main_package/core/gold/tests/transactions/test_gold__fact_transactions_full.sql
+++ b/models/main_package/core/gold/tests/transactions/test_gold__fact_transactions_full.sql
@@ -1,3 +1,6 @@
+{# Get variables #}
+{% set vars = return_vars() %}
+
 {# Log configuration details #}
 {{ log_model_details() }}
 

--- a/models/main_package/core/gold/tests/transactions/test_gold__fact_transactions_full.yml
+++ b/models/main_package/core/gold/tests/transactions/test_gold__fact_transactions_full.yml
@@ -6,7 +6,7 @@ models:
       - dbt_utils.unique_combination_of_columns:
           combination_of_columns:
             - TX_HASH
-      - fsc_utils.sequence_gaps:
+      - fsc_evm.sequence_gaps:
           partition_by:
             - BLOCK_NUMBER
           column_name: TX_POSITION

--- a/models/main_package/core/gold/tests/transactions/test_gold__fact_transactions_full.yml
+++ b/models/main_package/core/gold/tests/transactions/test_gold__fact_transactions_full.yml
@@ -85,8 +85,6 @@ models:
         tests:
           - not_null
       - name: GAS_USED
-        tests:
-          - not_null
       - name: GAS_LIMIT
         tests:
           - not_null

--- a/models/main_package/core/gold/tests/transactions/test_gold__fact_transactions_recent.sql
+++ b/models/main_package/core/gold/tests/transactions/test_gold__fact_transactions_recent.sql
@@ -1,3 +1,6 @@
+{# Get variables #}
+{% set vars = return_vars() %}
+
 {# Log configuration details #}
 {{ log_model_details() }}
 

--- a/models/main_package/core/gold/tests/transactions/test_gold__fact_transactions_recent.sql
+++ b/models/main_package/core/gold/tests/transactions/test_gold__fact_transactions_recent.sql
@@ -17,3 +17,12 @@ WHERE
         FROM
             {{ ref('_block_lookback') }}
     )
+{% if vars.MAIN_OBSERV_EXCLUSION_LIST_ENABLED %}
+AND
+    block_number NOT IN (
+        SELECT
+            block_number :: INT
+        FROM
+            observability.exclusion_list
+    )
+{% endif %}

--- a/models/main_package/core/gold/tests/transactions/test_gold__fact_transactions_recent.yml
+++ b/models/main_package/core/gold/tests/transactions/test_gold__fact_transactions_recent.yml
@@ -84,8 +84,6 @@ models:
         tests:
           - not_null
       - name: GAS_USED
-        tests:
-          - not_null
       - name: GAS_LIMIT
         tests:
           - not_null

--- a/models/main_package/core/gold/tests/transactions/test_gold__fact_transactions_recent.yml
+++ b/models/main_package/core/gold/tests/transactions/test_gold__fact_transactions_recent.yml
@@ -6,7 +6,7 @@ models:
       - dbt_utils.unique_combination_of_columns:
           combination_of_columns:
             - TX_HASH
-      - fsc_utils.sequence_gaps:
+      - fsc_evm.sequence_gaps:
           partition_by:
             - BLOCK_NUMBER
           column_name: TX_POSITION

--- a/models/main_package/core/nft/tests/test_nft__ez_nft_transfers_full.sql
+++ b/models/main_package/core/nft/tests/test_nft__ez_nft_transfers_full.sql
@@ -10,3 +10,12 @@ SELECT
     *
 FROM
     {{ ref('nft__ez_nft_transfers') }}
+{% if vars.MAIN_OBSERV_EXCLUSION_LIST_ENABLED %}
+WHERE
+    block_number NOT IN (
+        SELECT
+            block_number :: INT
+        FROM
+            observability.exclusion_list
+    )
+{% endif %}

--- a/models/main_package/core/nft/tests/test_nft__ez_nft_transfers_full.sql
+++ b/models/main_package/core/nft/tests/test_nft__ez_nft_transfers_full.sql
@@ -1,3 +1,6 @@
+{# Get variables #}
+{% set vars = return_vars() %}
+
 {# Log configuration details #}
 {{ log_model_details() }}
 

--- a/models/main_package/core/nft/tests/test_nft__ez_nft_transfers_recent.sql
+++ b/models/main_package/core/nft/tests/test_nft__ez_nft_transfers_recent.sql
@@ -1,3 +1,6 @@
+{# Get variables #}
+{% set vars = return_vars() %}
+
 {# Log configuration details #}
 {{ log_model_details() }}
 

--- a/models/main_package/core/nft/tests/test_nft__ez_nft_transfers_recent.sql
+++ b/models/main_package/core/nft/tests/test_nft__ez_nft_transfers_recent.sql
@@ -17,3 +17,12 @@ WHERE
         FROM
             {{ ref('_block_lookback') }}
     )
+{% if vars.MAIN_OBSERV_EXCLUSION_LIST_ENABLED %}
+AND
+    block_number NOT IN (
+        SELECT
+            block_number :: INT
+        FROM
+            observability.exclusion_list
+    )
+{% endif %}

--- a/models/main_package/core/silver/tests/blocks/test_silver__blocks_full.sql
+++ b/models/main_package/core/silver/tests/blocks/test_silver__blocks_full.sql
@@ -1,3 +1,6 @@
+{# Get variables #}
+{% set vars = return_vars() %}
+
 {# Log configuration details #}
 {{ log_model_details() }}
 
@@ -10,3 +13,12 @@ SELECT
     *
 FROM
     {{ ref('silver__blocks') }}
+{% if vars.MAIN_OBSERV_EXCLUSION_LIST_ENABLED %}
+WHERE
+    block_number NOT IN (
+        SELECT
+            block_number :: INT
+        FROM
+            observability.exclusion_list
+    )
+{% endif %}

--- a/models/main_package/core/silver/tests/blocks/test_silver__blocks_full.yml
+++ b/models/main_package/core/silver/tests/blocks/test_silver__blocks_full.yml
@@ -6,7 +6,7 @@ models:
       - dbt_utils.unique_combination_of_columns:
           combination_of_columns:
             - BLOCK_NUMBER
-      - fsc_utils.sequence_gaps:
+      - fsc_evm.sequence_gaps:
           column_name: BLOCK_NUMBER
           config:
             severity: error

--- a/models/main_package/core/silver/tests/blocks/test_silver__blocks_recent.sql
+++ b/models/main_package/core/silver/tests/blocks/test_silver__blocks_recent.sql
@@ -1,3 +1,6 @@
+{# Get variables #}
+{% set vars = return_vars() %}
+
 {# Log configuration details #}
 {{ log_model_details() }}
 
@@ -17,3 +20,12 @@ WHERE
         FROM
             {{ ref('_block_lookback') }}
     )
+{% if vars.MAIN_OBSERV_EXCLUSION_LIST_ENABLED %}
+AND
+    block_number NOT IN (
+        SELECT
+            block_number :: INT
+        FROM
+            observability.exclusion_list
+    )
+{% endif %}

--- a/models/main_package/core/silver/tests/blocks/test_silver__blocks_recent.yml
+++ b/models/main_package/core/silver/tests/blocks/test_silver__blocks_recent.yml
@@ -6,7 +6,7 @@ models:
       - dbt_utils.unique_combination_of_columns:
           combination_of_columns:
             - BLOCK_NUMBER
-      - fsc_utils.sequence_gaps:
+      - fsc_evm.sequence_gaps:
           column_name: BLOCK_NUMBER
           config:
             severity: error

--- a/models/main_package/core/silver/tests/confirm_blocks/test_silver__confirm_blocks_full.sql
+++ b/models/main_package/core/silver/tests/confirm_blocks/test_silver__confirm_blocks_full.sql
@@ -1,3 +1,6 @@
+{# Get variables #}
+{% set vars = return_vars() %}
+
 {# Log configuration details #}
 {{ log_model_details() }}
 
@@ -10,3 +13,12 @@ SELECT
     *
 FROM
     {{ ref('silver__confirm_blocks') }}
+{% if vars.MAIN_OBSERV_EXCLUSION_LIST_ENABLED %}
+WHERE
+    block_number NOT IN (
+        SELECT
+            block_number :: INT
+        FROM
+            observability.exclusion_list
+    )
+{% endif %}

--- a/models/main_package/core/silver/tests/confirm_blocks/test_silver__confirm_blocks_recent.sql
+++ b/models/main_package/core/silver/tests/confirm_blocks/test_silver__confirm_blocks_recent.sql
@@ -1,3 +1,6 @@
+{# Get variables #}
+{% set vars = return_vars() %}
+
 {# Log configuration details #}
 {{ log_model_details() }}
 
@@ -44,3 +47,12 @@ WHERE
         FROM
             {{ ref('_block_lookback') }}
     )
+{% if vars.MAIN_OBSERV_EXCLUSION_LIST_ENABLED %}
+AND
+    block_number NOT IN (
+        SELECT
+            block_number :: INT
+        FROM
+            observability.exclusion_list
+    )
+{% endif %}

--- a/models/main_package/core/silver/tests/receipts/test_silver__receipts_full.sql
+++ b/models/main_package/core/silver/tests/receipts/test_silver__receipts_full.sql
@@ -1,3 +1,6 @@
+{# Get variables #}
+{% set vars = return_vars() %}
+
 {# Log configuration details #}
 {{ log_model_details() }}
 
@@ -10,3 +13,12 @@ SELECT
     *
 FROM
     {{ ref('silver__receipts') }}
+{% if vars.MAIN_OBSERV_EXCLUSION_LIST_ENABLED %}
+WHERE
+    block_number NOT IN (
+        SELECT
+            block_number :: INT
+        FROM
+            observability.exclusion_list
+    )
+{% endif %}

--- a/models/main_package/core/silver/tests/receipts/test_silver__receipts_recent.sql
+++ b/models/main_package/core/silver/tests/receipts/test_silver__receipts_recent.sql
@@ -1,3 +1,6 @@
+{# Get variables #}
+{% set vars = return_vars() %}
+
 {# Log configuration details #}
 {{ log_model_details() }}
 
@@ -17,3 +20,12 @@ WHERE
         FROM
             {{ ref('_block_lookback') }}
     )
+{% if vars.MAIN_OBSERV_EXCLUSION_LIST_ENABLED %}
+AND
+    block_number NOT IN (
+        SELECT
+            block_number :: INT
+        FROM
+            observability.exclusion_list
+    )
+{% endif %}

--- a/models/main_package/core/silver/tests/traces/test_silver__traces_full.sql
+++ b/models/main_package/core/silver/tests/traces/test_silver__traces_full.sql
@@ -1,3 +1,6 @@
+{# Get variables #}
+{% set vars = return_vars() %}
+
 {# Log configuration details #}
 {{ log_model_details() }}
 
@@ -10,3 +13,12 @@ SELECT
     *
 FROM
     {{ ref('silver__traces') }}
+{% if vars.MAIN_OBSERV_EXCLUSION_LIST_ENABLED %}
+WHERE
+    block_number NOT IN (
+        SELECT
+            block_number :: INT
+        FROM
+            observability.exclusion_list
+    )
+{% endif %}

--- a/models/main_package/core/silver/tests/traces/test_silver__traces_recent.sql
+++ b/models/main_package/core/silver/tests/traces/test_silver__traces_recent.sql
@@ -1,3 +1,6 @@
+{# Get variables #}
+{% set vars = return_vars() %}
+
 {# Log configuration details #}
 {{ log_model_details() }}
 
@@ -17,3 +20,12 @@ WHERE
         FROM
             {{ ref('_block_lookback') }}
     )
+{% if vars.MAIN_OBSERV_EXCLUSION_LIST_ENABLED %}
+AND
+    block_number NOT IN (
+        SELECT
+            block_number :: INT
+        FROM
+            observability.exclusion_list
+    )
+{% endif %}

--- a/models/main_package/core/silver/tests/transactions/test_silver__transactions_full.sql
+++ b/models/main_package/core/silver/tests/transactions/test_silver__transactions_full.sql
@@ -1,3 +1,6 @@
+{# Get variables #}
+{% set vars = return_vars() %}
+
 {# Log configuration details #}
 {{ log_model_details() }}
 
@@ -10,3 +13,12 @@ SELECT
     *
 FROM
     {{ ref('silver__transactions') }}
+{% if vars.MAIN_OBSERV_EXCLUSION_LIST_ENABLED %}
+WHERE
+    block_number NOT IN (
+        SELECT
+            block_number :: INT
+        FROM
+            observability.exclusion_list
+    )
+{% endif %}

--- a/models/main_package/core/silver/tests/transactions/test_silver__transactions_full.yml
+++ b/models/main_package/core/silver/tests/transactions/test_silver__transactions_full.yml
@@ -6,7 +6,7 @@ models:
       - dbt_utils.unique_combination_of_columns:
           combination_of_columns:
             - TRANSACTIONS_ID
-      - fsc_utils.sequence_gaps:
+      - fsc_evm.sequence_gaps:
           partition_by:
             - BLOCK_NUMBER
           column_name: TX_POSITION

--- a/models/main_package/core/silver/tests/transactions/test_silver__transactions_recent.sql
+++ b/models/main_package/core/silver/tests/transactions/test_silver__transactions_recent.sql
@@ -1,3 +1,6 @@
+{# Get variables #}
+{% set vars = return_vars() %}
+
 {# Log configuration details #}
 {{ log_model_details() }}
 
@@ -17,3 +20,12 @@ WHERE
         FROM
             {{ ref('_block_lookback') }}
     )
+{% if vars.MAIN_OBSERV_EXCLUSION_LIST_ENABLED %}
+AND
+    block_number NOT IN (
+        SELECT
+            block_number :: INT
+        FROM
+            observability.exclusion_list
+    )
+{% endif %}

--- a/models/main_package/core/silver/tests/transactions/test_silver__transactions_recent.yml
+++ b/models/main_package/core/silver/tests/transactions/test_silver__transactions_recent.yml
@@ -6,7 +6,7 @@ models:
       - dbt_utils.unique_combination_of_columns:
           combination_of_columns:
             - TRANSACTIONS_ID
-      - fsc_utils.sequence_gaps:
+      - fsc_evm.sequence_gaps:
           partition_by:
             - BLOCK_NUMBER
           column_name: TX_POSITION

--- a/models/main_package/observability/observability__traces.sql
+++ b/models/main_package/observability/observability__traces.sql
@@ -123,6 +123,9 @@ gap_agg AS (
                     observability.exclusion_list
             )
         {% endif %}
+        {% if vars.GLOBAL_PROJECT_NAME == 'boba' %}
+            AND missing_block_number > 1041894
+        {% endif %}
 )
 SELECT
     'traces' AS test_name,


### PR DESCRIPTION
1. Excludes blocks in observability exclusion lists from tests, where applicable
2. Excludes boba blocks <= 1041894 from traces observe/tests
3. Excludes last 2 hours of blocks from missing decoded logs test to allow them to heal before alerting
4. Removes not_null tests on gas and gas_used
5. Requires `dbt run -m "fsc_evm,tag:recent_test" "fsc_evm,tag:full_test" --full-refresh` adhoc on all repos upgrading to this package version