### PR TITLE
An 6836/layerzero reads

### DIFF
--- a/models/curated_package/defi/bridge/layerzero/silver_bridge__layerzero_v2.sql
+++ b/models/curated_package/defi/bridge/layerzero/silver_bridge__layerzero_v2.sql
@@ -107,7 +107,7 @@ SELECT
     dst_chain_id,
     dst_chain_id :: STRING AS destination_chain_id,
     dst_chain AS destination_chain,
-    contract_address AS token_address,
+    token_address,
     amount_sent AS amount_unadj,
     src_chain_id,
     src_chain,
@@ -122,11 +122,14 @@ SELECT
         '-',
         event_index
     ) AS _log_id,
-    inserted_timestamp,
-    modified_timestamp
+    o.inserted_timestamp,
+    o.modified_timestamp
 FROM
     oft_raw o
     INNER JOIN layerzero l USING (
         tx_hash,
         guid
+    )
+    INNER JOIN {{ ref('silver_bridge__layerzero_v2_token_reads') }} USING (
+        contract_address
     )

--- a/models/curated_package/defi/bridge/layerzero/silver_bridge__layerzero_v2.sql
+++ b/models/curated_package/defi/bridge/layerzero/silver_bridge__layerzero_v2.sql
@@ -107,7 +107,7 @@ SELECT
     dst_chain_id,
     dst_chain_id :: STRING AS destination_chain_id,
     dst_chain AS destination_chain,
-    token_address,
+    coalesce(token_address, contract_address) AS token_address,
     amount_sent AS amount_unadj,
     src_chain_id,
     src_chain,

--- a/models/curated_package/defi/bridge/layerzero/silver_bridge__layerzero_v2_token_reads.sql
+++ b/models/curated_package/defi/bridge/layerzero/silver_bridge__layerzero_v2_token_reads.sql
@@ -66,11 +66,12 @@ node_call AS (
             rpc_request,
             '{{ vars.GLOBAL_NODE_VAULT_PATH }}'
         ) AS response,
-        '0x' || LOWER(SUBSTR(response :data :result :: STRING, 25, 40)) AS token_address
+        '0x' || LOWER(SUBSTR(response :data :result :: STRING, 27, 40)) AS token_address
     FROM
         ready_reads
 )
 SELECT
+    response, 
     contract_address,
     token_address,
     SYSDATE() AS modified_timestamp,

--- a/models/curated_package/defi/bridge/layerzero/silver_bridge__layerzero_v2_token_reads.sql
+++ b/models/curated_package/defi/bridge/layerzero/silver_bridge__layerzero_v2_token_reads.sql
@@ -72,12 +72,12 @@ node_call AS (
 )
 SELECT
     response,
+    contract_address,
     IFF(
-        contract_address = '0x0000000000000000000000000000000000000000',
+        token_address = '0x0000000000000000000000000000000000000000',
         '{{ vars.GLOBAL_WRAPPED_NATIVE_ASSET_ADDRESS }}',
-        contract_address
-    ) AS contract_address,
-    token_address,
+        token_address
+    ) AS token_address,
     SYSDATE() AS modified_timestamp,
     SYSDATE() AS inserted_timestamp
 FROM

--- a/models/curated_package/defi/bridge/layerzero/silver_bridge__layerzero_v2_token_reads.sql
+++ b/models/curated_package/defi/bridge/layerzero/silver_bridge__layerzero_v2_token_reads.sql
@@ -8,6 +8,7 @@
     materialized = 'incremental',
     incremental_strategy = 'delete+insert',
     unique_key = "contract_address",
+    full_refresh = false,
     tags = ['silver_bridge','defi','bridge','curated']
 ) }}
 
@@ -71,8 +72,12 @@ node_call AS (
         ready_reads
 )
 SELECT
-    response, 
-    contract_address,
+    response,
+    IF(
+        contract_address = '0x0000000000000000000000000000000000000000',
+        '{{ vars.GLOBAL_WRAPPED_NATIVE_ASSET_ADDRESS }}',
+        contract_address
+    ) AS contract_address,
     token_address,
     SYSDATE() AS modified_timestamp,
     SYSDATE() AS inserted_timestamp

--- a/models/curated_package/defi/bridge/layerzero/silver_bridge__layerzero_v2_token_reads.sql
+++ b/models/curated_package/defi/bridge/layerzero/silver_bridge__layerzero_v2_token_reads.sql
@@ -49,6 +49,7 @@ ready_reads AS (
             'eth_call',
             [{'to': contract_address, 'from': null, 'data': input}]
         ) AS rpc_request
+        FROM new_tokens
 ),
 node_call AS (
     SELECT

--- a/models/curated_package/defi/bridge/layerzero/silver_bridge__layerzero_v2_token_reads.sql
+++ b/models/curated_package/defi/bridge/layerzero/silver_bridge__layerzero_v2_token_reads.sql
@@ -8,7 +8,6 @@
     materialized = 'incremental',
     incremental_strategy = 'delete+insert',
     unique_key = "contract_address",
-    --full_refresh = false,
     tags = ['silver_bridge','defi','bridge','curated']
 ) }}
 

--- a/models/curated_package/defi/bridge/layerzero/silver_bridge__layerzero_v2_token_reads.sql
+++ b/models/curated_package/defi/bridge/layerzero/silver_bridge__layerzero_v2_token_reads.sql
@@ -73,7 +73,7 @@ node_call AS (
 )
 SELECT
     response,
-    IF(
+    IFF(
         contract_address = '0x0000000000000000000000000000000000000000',
         '{{ vars.GLOBAL_WRAPPED_NATIVE_ASSET_ADDRESS }}',
         contract_address

--- a/models/curated_package/defi/bridge/layerzero/silver_bridge__layerzero_v2_token_reads.sql
+++ b/models/curated_package/defi/bridge/layerzero/silver_bridge__layerzero_v2_token_reads.sql
@@ -28,6 +28,8 @@ AND modified_timestamp >= (
     FROM
         {{ this }}
 )
+AND modified_timestamp >= CURRENT_DATE() - INTERVAL '7 day'
+
 AND contract_address NOT IN (
     SELECT
         contract_address

--- a/models/curated_package/defi/bridge/layerzero/silver_bridge__layerzero_v2_token_reads.sql
+++ b/models/curated_package/defi/bridge/layerzero/silver_bridge__layerzero_v2_token_reads.sql
@@ -1,0 +1,78 @@
+{# Set variables #}
+{% set vars = return_vars() %}
+
+{# Log configuration details #}
+{{ log_model_details() }}
+
+{{ config(
+    materialized = 'incremental',
+    incremental_strategy = 'delete+insert',
+    unique_key = "contract_address",
+    tags = ['silver_bridge','defi','bridge','curated']
+) }}
+
+WITH new_tokens AS (
+
+    SELECT
+        DISTINCT contract_address
+    FROM
+        {{ ref('core__fact_event_logs') }}
+    WHERE
+        block_timestamp :: DATE >= '2024-01-01'
+        AND topic_0 = '0x85496b760a4b7f8d66384b9df21b381f5d1b1e79f229a47aaf4c232edc2fe59a' --OFTSent
+
+{% if is_incremental() %}
+AND modified_timestamp >= (
+    SELECT
+        MAX(modified_timestamp) - INTERVAL '{{ var("LOOKBACK", "12 hours") }}'
+    FROM
+        {{ this }}
+)
+AND contract_address NOT IN (
+    SELECT
+        contract_address
+    FROM
+        {{ this }}
+)
+{% endif %}
+),
+ready_reads AS (
+    SELECT
+        contract_address,
+        '0xfc0c546a' AS function_sig,
+        RPAD(
+            function_sig,
+            64,
+            '0'
+        ) AS input,
+        utils.udf_json_rpc_call(
+            'eth_call',
+            [{'to': contract_address, 'from': null, 'data': input}]
+        ) AS rpc_request
+),
+node_call AS (
+    SELECT
+        contract_address,
+        live.udf_api(
+            'POST',
+            '{URL}',
+            OBJECT_CONSTRUCT(
+                'Content-Type',
+                'application/json',
+                'fsc-quantum-state',
+                'livequery'
+            ),
+            rpc_request,
+            '{{ vars.GLOBAL_NODE_VAULT_PATH }}'
+        ) AS response,
+        '0x' || LOWER(SUBSTR(response :data :result :: STRING, 25, 40)) AS token_address
+    FROM
+        ready_reads
+)
+SELECT
+    contract_address,
+    token_address,
+    SYSDATE() AS modified_timestamp,
+    SYSDATE() AS inserted_timestamp
+FROM
+    node_call

--- a/models/curated_package/defi/bridge/layerzero/silver_bridge__layerzero_v2_token_reads.sql
+++ b/models/curated_package/defi/bridge/layerzero/silver_bridge__layerzero_v2_token_reads.sql
@@ -8,7 +8,7 @@
     materialized = 'incremental',
     incremental_strategy = 'delete+insert',
     unique_key = "contract_address",
-    full_refresh = false,
+    --full_refresh = false,
     tags = ['silver_bridge','defi','bridge','curated']
 ) }}
 

--- a/models/curated_package/defi/bridge/layerzero/silver_bridge__layerzero_v2_token_reads.sql
+++ b/models/curated_package/defi/bridge/layerzero/silver_bridge__layerzero_v2_token_reads.sql
@@ -48,7 +48,7 @@ ready_reads AS (
         ) AS input,
         utils.udf_json_rpc_call(
             'eth_call',
-            [{'to': contract_address, 'from': null, 'data': input}]
+            [{'to': contract_address, 'from': null, 'data': input}, 'latest']
         ) AS rpc_request
         FROM new_tokens
 ),

--- a/models/curated_package/defi/bridge/layerzero/silver_bridge__layerzero_v2_token_reads.yml
+++ b/models/curated_package/defi/bridge/layerzero/silver_bridge__layerzero_v2_token_reads.yml
@@ -1,0 +1,14 @@
+version: 2
+models:
+  - name: silver_bridge__layerzero_v2_token_reads
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - CONTRACT_ADDRESS
+    columns:
+      - name: CONTRACT_ADDRESS
+        tests:
+          - not_null
+      - name: TOKEN_ADDRESS
+        tests:
+          - not_null

--- a/models/main_package/core/gold/core__ez_token_transfers.sql
+++ b/models/main_package/core/gold/core__ez_token_transfers.sql
@@ -12,7 +12,7 @@
     incremental_predicates = [fsc_evm.standard_predicate()],
     full_refresh = vars.GLOBAL_GOLD_FR_ENABLED,
     post_hook = "ALTER TABLE {{ this }} ADD SEARCH OPTIMIZATION ON EQUALITY(origin_from_address, origin_to_address, from_address, to_address, origin_function_signature), SUBSTRING(origin_from_address, origin_to_address, from_address, to_address, origin_function_signature)",
-    tags = ['gold','core','transfers','ez','phase_3']
+    tags = ['gold','core','transfers','ez','phase_3', 'heal']
 ) }}
 
 WITH base AS (
@@ -110,7 +110,28 @@ AND f.modified_timestamp > (
 {% endif %}
 )
 {% if is_incremental() %}
-, heal_prices as (
+, broken_records as (
+    SELECT
+        *
+    FROM
+        {{ this }}
+    WHERE
+        block_timestamp::DATE > dateadd('day', 
+        {% if var('HEAL_MODEL') %}
+            -31
+        {% else %}
+            -3
+        {% endif %}
+        , 
+            SYSDATE())
+        AND (
+            amount_usd IS NULL
+            OR decimals IS NULL
+            OR symbol IS NULL
+            OR name IS NULL
+        )
+),
+heal_prices as (
 SELECT
     t0.block_number,
     t0.block_timestamp,
@@ -152,7 +173,7 @@ SELECT
     SYSDATE() AS inserted_timestamp,
     SYSDATE() AS modified_timestamp
 FROM
-    {{ this }}
+    broken_records
     t0
     INNER JOIN {{ ref('price__ez_prices_hourly') }}
     p0
@@ -161,7 +182,7 @@ FROM
         t0.block_timestamp
     ) = HOUR
     AND t0.contract_address = p0.token_address
-WHERE t0.amount_usd IS NULL AND t0.block_timestamp > dateadd('day', -31, SYSDATE())
+WHERE t0.amount_usd IS NULL
 ),
 heal_metadata as (
 SELECT
@@ -190,16 +211,15 @@ SELECT
     SYSDATE() AS inserted_timestamp,
     SYSDATE() AS modified_timestamp
 FROM    
-    {{ this }}
+    broken_records
     t0
     INNER JOIN {{ ref('core__dim_contracts') }}
     c0
     ON t0.contract_address = c0.address
-    WHERE t0.block_timestamp > dateadd('day', -31, SYSDATE())
-    and (
-    (t0.symbol IS NULL AND c0.symbol IS NOT NULL) 
-    OR (t0.name IS NULL AND c0.name IS NOT NULL)
-    OR (t0.decimals IS NULL AND c0.decimals IS NOT NULL)
+    WHERE (
+        (t0.symbol IS NULL AND c0.symbol IS NOT NULL) 
+        OR (t0.name IS NULL AND c0.name IS NOT NULL)
+        OR (t0.decimals IS NULL AND c0.decimals IS NOT NULL)
     ) 
 )
 {% endif %}


### PR DESCRIPTION
This change adds a token reads model to read the underlying token address represented by the Layerzero OFT address. Some tokens use the same address for its OFT while others don't, this reads pipeline would solve that. Not expecting a lot of reads each incremental run, at most 1 new token a day 

requires a version bump on chains with Layerzero v2

`dbt run -m silver_bridge__layerzero_v2_token_reads silver_bridge__layerzero_v2 --full-refresh && dbt run -m models/silver/defi/bridge/silver_bridge__complete_bridge_activity.sql --vars '{"HEAL_MODELS": ["layerzero_v2"]}'`






