### PR TITLE
Fix Avalanche daily test: Add symbiosis-v1 to recency exclusion list

### DIFF
--- a/macros/global/variables/project_vars/avalanche_vars.sql
+++ b/macros/global/variables/project_vars/avalanche_vars.sql
@@ -20,7 +20,7 @@
         'MAIN_GHA_SCHEDULED_SCORES_CRON': '10 5 * * *',
         'CUSTOM_GHA_STREAMLINE_DEXALOT_CHAINHEAD_CRON': '50 * * * *',
         'CUSTOM_GHA_SCHEDULED_DEXALOT_MAIN_CRON': '5 * * * *',
-        'CURATED_DEFI_RECENCY_EXCLUSION_LIST': ['allbridge-v1','multichain-v7','platypus-v1','gmx-v1','woofi-v1','hashflow-v1'],
+        'CURATED_DEFI_RECENCY_EXCLUSION_LIST': ['allbridge-v1','multichain-v7','platypus-v1','gmx-v1','woofi-v1','hashflow-v1','symbiosis-v1'],
         'CURATED_DEFI_DEX_SWAPS_CONTRACT_MAPPING': {
             'arena_trade': {
                 'v1': {


### PR DESCRIPTION
## Summary
- Add symbiosis-v1 to CURATED_DEFI_RECENCY_EXCLUSION_LIST for Avalanche
- Fixes daily test failure in avalanche-models caused by inactive bridge protocol

## Root Cause
- Symbiosis bridge protocol has been inactive for 30+ days (latest activity July 16)
- Current 30-day period has 0 events vs 1476 rolling average (0% activity)
- Test fails because activity is below 10% threshold

## Deployment plan
- Deploy to avalanche-models via package update

## Test plan
- Daily tests should pass once deployed
- Verify symbiosis-v1 is excluded from future recency checks