### PR TITLE
polygon: exclude meson-v1 from curated recency tests

### DIFF
--- a/macros/global/variables/project_vars/polygon_vars.sql
+++ b/macros/global/variables/project_vars/polygon_vars.sql
@@ -22,7 +22,7 @@
         'MAIN_CORE_BRONZE_TOKEN_READS_BATCHED_ENABLED': true,
         'MAIN_OBSERV_EXCLUSION_LIST_ENABLED': true,
         'BALANCES_SL_START_DATE': '2025-06-10',
-        'CURATED_DEFI_RECENCY_EXCLUSION_LIST': ['hashflow-v1','woofi-v1','synapse-v1','across-v1','allbridge-v1','multichain-v7','hop-v1','symbiosis-v1','curve-v1','aave-v2'],
+        'CURATED_DEFI_RECENCY_EXCLUSION_LIST': ['hashflow-v1','woofi-v1','synapse-v1','across-v1','allbridge-v1','multichain-v7','hop-v1','symbiosis-v1','curve-v1','aave-v2','meson-v1'],
         'CURATED_DEFI_DEX_SWAPS_CONTRACT_MAPPING': {
             'uniswap': {
                 'v2': {


### PR DESCRIPTION
## Summary
- Add meson-v1 to CURATED_DEFI_RECENCY_EXCLUSION_LIST in polygon_vars

## Root Cause
- meson-v1 bridge platform failing curated recency test with 9.69% delta
- Low activity platform with 3-hour data gap causing recency threshold violations
- Latest data: 2025-09-19 07:47:34 vs system time: 2025-09-19 10:50:05

## Test plan
- Verify polygon daily tests pass after exclusion